### PR TITLE
Update extension to use major.minor versioning scheme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nimbus-devtools",
-  "version": "1.0.0",
+  "version": "1.0",
   "description": "nimbus-devtools",
   "license": "MPL-2.0",
   "private": true,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "nimbus-devtools",
-  "version": "1.0.0",
+  "version": "1.0",
   "browser_specific_settings": {
     "gecko": {
       "id": "nimbus-devtools@mozilla.com",


### PR DESCRIPTION
This change is needed for https://github.com/mozilla-extensions/xpi-manifest/pull/215

In [Bug 1793925](https://bugzilla.mozilla.org/show_bug.cgi?id=1793925), Firefox Desktop started to emit warnings when an extension's version doesn't match the format specified in the [MDN docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version#version_format).

To comply with this format, we need to drop the patch version on the add on pipeline web extensions.

The pipeline will now generate versions as `major.minor.date.time`