### PR TITLE
Fix npm audits and update web-ext

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "prettier": "^3.0.0",
         "typescript": "^5.1.6",
         "watcher": "^2.2.2",
-        "web-ext": "^7.6.2",
+        "web-ext": "^7.11.0",
         "web-ext-types": "^3.2.1"
       }
     },
@@ -654,9 +654,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.1.tgz",
-      "integrity": "sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -692,35 +692,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
-      "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/espree": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.9.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -740,9 +711,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.46.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.46.0.tgz",
-      "integrity": "sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+      "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -759,18 +730,24 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
       "dev": true,
       "dependencies": {
-        "@humanwhocodes/object-schema": "^1.2.1",
-        "debug": "^4.1.1",
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
       "engines": {
         "node": ">=10.10.0"
       }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "dev": true
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
@@ -789,7 +766,52 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-      "dev": true
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",
@@ -846,24 +868,24 @@
       "dev": true
     },
     "node_modules/@lezer/common": {
-      "version": "0.15.12",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
-      "integrity": "sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.1.tgz",
+      "integrity": "sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ==",
       "dev": true
     },
     "node_modules/@lezer/lr": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.8.tgz",
-      "integrity": "sha512-bM6oE6VQZ6hIFxDNKk8bKPa14hqFrV07J/vHGOeiAbJReIaQXmkVb6xQu4MR+JBTLa5arGRyAAjJe1qaQt3Uvg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.0.tgz",
+      "integrity": "sha512-Wst46p51km8gH0ZUmeNrtpRYmdlRHUpN1DQd3GFAyKANi8WVz8c2jHYTf1CVScFaCjQw1iO3ZZdqGDxQPRErTg==",
       "dev": true,
       "dependencies": {
-        "@lezer/common": "^0.15.0"
+        "@lezer/common": "^1.0.0"
       }
     },
     "node_modules/@lmdb/lmdb-darwin-arm64": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.7.11.tgz",
-      "integrity": "sha512-r6+vYq2vKzE+vgj/rNVRMwAevq0+ZR9IeMFIqcSga+wMtMdXQ27KqQ7uS99/yXASg29bos7yHP3yk4x6Iio0lw==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.8.5.tgz",
+      "integrity": "sha512-KPDeVScZgA1oq0CiPBcOa3kHIqU+pTOwRFDIhxvmf8CTNvqdZQYp5cCKW0bUk69VygB2PuTiINFWbY78aR2pQw==",
       "cpu": [
         "arm64"
       ],
@@ -874,9 +896,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-darwin-x64": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.7.11.tgz",
-      "integrity": "sha512-jhj1aB4K8ycRL1HOQT5OtzlqOq70jxUQEWRN9Gqh3TIDN30dxXtiHi6EWF516tzw6v2+3QqhDMJh8O6DtTGG8Q==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.8.5.tgz",
+      "integrity": "sha512-w/sLhN4T7MW1nB3R/U8WK5BgQLz904wh+/SmA2jD8NnF7BLLoUgflCNxOeSPOWp8geP6nP/+VjWzZVip7rZ1ug==",
       "cpu": [
         "x64"
       ],
@@ -887,9 +909,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-linux-arm": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.7.11.tgz",
-      "integrity": "sha512-dHfLFVSrw/v5X5lkwp0Vl7+NFpEeEYKfMG2DpdFJnnG1RgHQZngZxCaBagFoaJGykRpd2DYF1AeuXBFrAUAXfw==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.8.5.tgz",
+      "integrity": "sha512-c0TGMbm2M55pwTDIfkDLB6BpIsgxV4PjYck2HiOX+cy/JWiBXz32lYbarPqejKs9Flm7YVAKSILUducU9g2RVg==",
       "cpu": [
         "arm"
       ],
@@ -900,9 +922,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-linux-arm64": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.7.11.tgz",
-      "integrity": "sha512-7xGEfPPbmVJWcY2Nzqo11B9Nfxs+BAsiiaY/OcT4aaTDdykKeCjvKMQJA3KXCtZ1AtiC9ljyGLi+BfUwdulY5A==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.8.5.tgz",
+      "integrity": "sha512-vtbZRHH5UDlL01TT5jB576Zox3+hdyogvpcbvVJlmU5PdL3c5V7cj1EODdh1CHPksRl+cws/58ugEHi8bcj4Ww==",
       "cpu": [
         "arm64"
       ],
@@ -913,9 +935,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-linux-x64": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.7.11.tgz",
-      "integrity": "sha512-vUKI3JrREMQsXX8q0Eq5zX2FlYCKWMmLiCyyJNfZK0Uyf14RBg9VtB3ObQ41b4swYh2EWaltasWVe93Y8+KDng==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.8.5.tgz",
+      "integrity": "sha512-Xkc8IUx9aEhP0zvgeKy7IQ3ReX2N8N1L0WPcQwnZweWmOuKfwpS3GRIYqLtK5za/w3E60zhFfNdS+3pBZPytqQ==",
       "cpu": [
         "x64"
       ],
@@ -926,9 +948,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-win32-x64": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.7.11.tgz",
-      "integrity": "sha512-BJwkHlSUgtB+Ei52Ai32M1AOMerSlzyIGA/KC4dAGL+GGwVMdwG8HGCOA2TxP3KjhbgDPMYkv7bt/NmOmRIFng==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.8.5.tgz",
+      "integrity": "sha512-4wvrf5BgnR8RpogHhtpCPJMKBmvyZPhhUtEwMJbXh0ni2BucpfF07jlmyM11zRqQ2XIq6PbC2j7W7UCCcm1rRQ==",
       "cpu": [
         "x64"
       ],
@@ -939,9 +961,9 @@
       ]
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "5.2.42",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.42.tgz",
-      "integrity": "sha512-CD/2ai1W45cDN/zN2AcYduDavU+nq9aStyQizi4MHxnwkRvS/H24WIjgc1qD8CISoqXa8AAIe+A+zpWxwV7a2Q==",
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.5.7.tgz",
+      "integrity": "sha512-DoHTZ/TjtNfUu9eiqJd+x3IcCQrhS+yOYU436TKUnlE36jZwNbK535D1CmTsSYdi/UcdCWNm5KRQZ9g1tlZCPw==",
       "dev": true
     },
     "node_modules/@microsoft/eslint-plugin-sdl": {
@@ -1292,13 +1314,13 @@
       }
     },
     "node_modules/@mischnic/json-sourcemap": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.0.tgz",
-      "integrity": "sha512-dQb3QnfNqmQNYA4nFSN/uLaByIic58gOXq4Y4XqLOWmOrw73KmJPt/HLyG0wvn1bnR6mBKs/Uwvkh+Hns1T0XA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.1.tgz",
+      "integrity": "sha512-iA7+tyVqfrATAIsIRWQG+a7ZLLD0VaOCKV2Wd/v4mqIU3J9c4jx9p7S0nw1XH3gJCKNBOOwACOPYYSUu9pgT+w==",
       "dev": true,
       "dependencies": {
-        "@lezer/common": "^0.15.7",
-        "@lezer/lr": "^0.15.4",
+        "@lezer/common": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
         "json5": "^2.2.1"
       },
       "engines": {
@@ -1462,21 +1484,21 @@
       }
     },
     "node_modules/@parcel/bundler-default": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.9.3.tgz",
-      "integrity": "sha512-JjJK8dq39/UO/MWI/4SCbB1t/qgpQRFnFDetAAAezQ8oN++b24u1fkMDa/xqQGjbuPmGeTds5zxGgYs7id7PYg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.12.0.tgz",
+      "integrity": "sha512-3ybN74oYNMKyjD6V20c9Gerdbh7teeNvVMwIoHIQMzuIFT6IGX53PyOLlOKRLbjxMc0TMimQQxIt2eQqxR5LsA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/graph": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/graph": "3.2.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1484,15 +1506,15 @@
       }
     },
     "node_modules/@parcel/cache": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.9.3.tgz",
-      "integrity": "sha512-Bj/H2uAJJSXtysG7E/x4EgTrE2hXmm7td/bc97K8M9N7+vQjxf7xb0ebgqe84ePVMkj4MVQSMEJkEucXVx4b0Q==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.12.0.tgz",
+      "integrity": "sha512-FX5ZpTEkxvq/yvWklRHDESVRz+c7sLTXgFuzz6uEnBcXV38j6dMSikflNpHA6q/L4GKkCqRywm9R6XQwhwIMyw==",
       "dev": true,
       "dependencies": {
-        "@parcel/fs": "2.9.3",
-        "@parcel/logger": "2.9.3",
-        "@parcel/utils": "2.9.3",
-        "lmdb": "2.7.11"
+        "@parcel/fs": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "lmdb": "2.8.5"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -1502,13 +1524,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.9.3"
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@parcel/codeframe": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.9.3.tgz",
-      "integrity": "sha512-z7yTyD6h3dvduaFoHpNqur74/2yDWL++33rjQjIjCaXREBN6dKHoMGMizzo/i4vbiI1p9dDox2FIDEHCMQxqdA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.12.0.tgz",
+      "integrity": "sha512-v2VmneILFiHZJTxPiR7GEF1wey1/IXPdZMcUlNXBiPZyWDfcuNgGGVQkx/xW561rULLIvDPharOMdxz5oHOKQg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0"
@@ -1522,16 +1544,16 @@
       }
     },
     "node_modules/@parcel/compressor-raw": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.9.3.tgz",
-      "integrity": "sha512-jz3t4/ICMsHEqgiTmv5i1DJva2k5QRpZlBELVxfY+QElJTVe8edKJ0TiKcBxh2hx7sm4aUigGmp7JiqqHRRYmA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.12.0.tgz",
+      "integrity": "sha512-h41Q3X7ZAQ9wbQ2csP8QGrwepasLZdXiuEdpUryDce6rF9ZiHoJ97MRpdLxOhOPyASTw/xDgE1xyaPQr0Q3f5A==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3"
+        "@parcel/plugin": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1539,71 +1561,72 @@
       }
     },
     "node_modules/@parcel/config-default": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.9.3.tgz",
-      "integrity": "sha512-tqN5tF7QnVABDZAu76co5E6N8mA9n8bxiWdK4xYyINYFIEHgX172oRTqXTnhEMjlMrdmASxvnGlbaPBaVnrCTw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.12.0.tgz",
+      "integrity": "sha512-dPNe2n9eEsKRc1soWIY0yToMUPirPIa2QhxcCB3Z5RjpDGIXm0pds+BaiqY6uGLEEzsjhRO0ujd4v2Rmm0vuFg==",
       "dev": true,
       "dependencies": {
-        "@parcel/bundler-default": "2.9.3",
-        "@parcel/compressor-raw": "2.9.3",
-        "@parcel/namer-default": "2.9.3",
-        "@parcel/optimizer-css": "2.9.3",
-        "@parcel/optimizer-htmlnano": "2.9.3",
-        "@parcel/optimizer-image": "2.9.3",
-        "@parcel/optimizer-svgo": "2.9.3",
-        "@parcel/optimizer-swc": "2.9.3",
-        "@parcel/packager-css": "2.9.3",
-        "@parcel/packager-html": "2.9.3",
-        "@parcel/packager-js": "2.9.3",
-        "@parcel/packager-raw": "2.9.3",
-        "@parcel/packager-svg": "2.9.3",
-        "@parcel/reporter-dev-server": "2.9.3",
-        "@parcel/resolver-default": "2.9.3",
-        "@parcel/runtime-browser-hmr": "2.9.3",
-        "@parcel/runtime-js": "2.9.3",
-        "@parcel/runtime-react-refresh": "2.9.3",
-        "@parcel/runtime-service-worker": "2.9.3",
-        "@parcel/transformer-babel": "2.9.3",
-        "@parcel/transformer-css": "2.9.3",
-        "@parcel/transformer-html": "2.9.3",
-        "@parcel/transformer-image": "2.9.3",
-        "@parcel/transformer-js": "2.9.3",
-        "@parcel/transformer-json": "2.9.3",
-        "@parcel/transformer-postcss": "2.9.3",
-        "@parcel/transformer-posthtml": "2.9.3",
-        "@parcel/transformer-raw": "2.9.3",
-        "@parcel/transformer-react-refresh-wrap": "2.9.3",
-        "@parcel/transformer-svg": "2.9.3"
+        "@parcel/bundler-default": "2.12.0",
+        "@parcel/compressor-raw": "2.12.0",
+        "@parcel/namer-default": "2.12.0",
+        "@parcel/optimizer-css": "2.12.0",
+        "@parcel/optimizer-htmlnano": "2.12.0",
+        "@parcel/optimizer-image": "2.12.0",
+        "@parcel/optimizer-svgo": "2.12.0",
+        "@parcel/optimizer-swc": "2.12.0",
+        "@parcel/packager-css": "2.12.0",
+        "@parcel/packager-html": "2.12.0",
+        "@parcel/packager-js": "2.12.0",
+        "@parcel/packager-raw": "2.12.0",
+        "@parcel/packager-svg": "2.12.0",
+        "@parcel/packager-wasm": "2.12.0",
+        "@parcel/reporter-dev-server": "2.12.0",
+        "@parcel/resolver-default": "2.12.0",
+        "@parcel/runtime-browser-hmr": "2.12.0",
+        "@parcel/runtime-js": "2.12.0",
+        "@parcel/runtime-react-refresh": "2.12.0",
+        "@parcel/runtime-service-worker": "2.12.0",
+        "@parcel/transformer-babel": "2.12.0",
+        "@parcel/transformer-css": "2.12.0",
+        "@parcel/transformer-html": "2.12.0",
+        "@parcel/transformer-image": "2.12.0",
+        "@parcel/transformer-js": "2.12.0",
+        "@parcel/transformer-json": "2.12.0",
+        "@parcel/transformer-postcss": "2.12.0",
+        "@parcel/transformer-posthtml": "2.12.0",
+        "@parcel/transformer-raw": "2.12.0",
+        "@parcel/transformer-react-refresh-wrap": "2.12.0",
+        "@parcel/transformer-svg": "2.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.9.3"
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@parcel/core": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.9.3.tgz",
-      "integrity": "sha512-4KlM1Zr/jpsqWuMXr2zmGsaOUs1zMMFh9vfCNKRZkptf+uk8I3sugHbNdo+F5B+4e2yMuOEb1zgAmvJLeuH6ww==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.12.0.tgz",
+      "integrity": "sha512-s+6pwEj+GfKf7vqGUzN9iSEPueUssCCQrCBUlcAfKrJe0a22hTUCjewpB0I7lNrCIULt8dkndD+sMdOrXsRl6Q==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.9.3",
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/events": "2.9.3",
-        "@parcel/fs": "2.9.3",
-        "@parcel/graph": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/logger": "2.9.3",
-        "@parcel/package-manager": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/profiler": "2.9.3",
+        "@parcel/cache": "2.12.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/events": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/graph": "3.2.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/package-manager": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/profiler": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
-        "@parcel/workers": "2.9.3",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0",
         "abortcontroller-polyfill": "^1.1.9",
         "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
@@ -1611,7 +1634,7 @@
         "dotenv": "^7.0.0",
         "dotenv-expand": "^5.1.0",
         "json5": "^2.2.0",
-        "msgpackr": "^1.5.4",
+        "msgpackr": "^1.9.9",
         "nullthrows": "^1.1.1",
         "semver": "^7.5.2"
       },
@@ -1644,37 +1667,10 @@
         "node": ">=6"
       }
     },
-    "node_modules/@parcel/core/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@parcel/core/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@parcel/diagnostic": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.9.3.tgz",
-      "integrity": "sha512-6jxBdyB3D7gP4iE66ghUGntWt2v64E6EbD4AetZk+hNJpgudOOPsKTovcMi/i7I4V0qD7WXSF4tvkZUoac0jwA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.12.0.tgz",
+      "integrity": "sha512-8f1NOsSFK+F4AwFCKynyIu9Kr/uWHC+SywAv4oS6Bv3Acig0gtwUjugk0C9UaB8ztBZiW5TQZhw+uPZn9T/lJA==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
@@ -1689,9 +1685,9 @@
       }
     },
     "node_modules/@parcel/events": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.9.3.tgz",
-      "integrity": "sha512-K0Scx+Bx9f9p1vuShMzNwIgiaZUkxEnexaKYHYemJrM7pMAqxIuIqhnvwurRCsZOVLUJPDDNJ626cWTc5vIq+A==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.12.0.tgz",
+      "integrity": "sha512-nmAAEIKLjW1kB2cUbCYSmZOGbnGj8wCzhqnK727zCCWaA25ogzAtt657GPOeFyqW77KyosU728Tl63Fc8hphIA==",
       "dev": true,
       "engines": {
         "node": ">= 12.0.0"
@@ -1702,16 +1698,16 @@
       }
     },
     "node_modules/@parcel/fs": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.9.3.tgz",
-      "integrity": "sha512-/PrRKgCRw22G7rNPSpgN3Q+i2nIkZWuvIOAdMG4KWXC4XLp8C9jarNaWd5QEQ75amjhQSl3oUzABzkdCtkKrgg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.12.0.tgz",
+      "integrity": "sha512-NnFkuvou1YBtPOhTdZr44WN7I60cGyly2wpHzqRl62yhObyi1KvW0SjwOMa0QGNcBOIzp4G0CapoZ93hD0RG5Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/fs-search": "2.9.3",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/rust": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "@parcel/watcher": "^2.0.7",
-        "@parcel/workers": "2.9.3"
+        "@parcel/workers": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -1721,26 +1717,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.9.3"
-      }
-    },
-    "node_modules/@parcel/fs-search": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.9.3.tgz",
-      "integrity": "sha512-nsNz3bsOpwS+jphcd+XjZL3F3PDq9lik0O8HPm5f6LYkqKWT+u/kgQzA8OkAHCR3q96LGiHxUywHPEBc27vI4Q==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@parcel/graph": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.9.3.tgz",
-      "integrity": "sha512-3LmRJmF8+OprAr6zJT3X2s8WAhLKkrhi6RsFlMWHifGU5ED1PFcJWFbOwJvSjcAhMQJP0fErcFIK1Ludv3Vm3g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.2.0.tgz",
+      "integrity": "sha512-xlrmCPqy58D4Fg5umV7bpwDx5Vyt7MlnQPxW68vae5+BA4GSWetfZt+Cs5dtotMG2oCHzZxhIPt7YZ7NRyQzLA==",
       "dev": true,
       "dependencies": {
         "nullthrows": "^1.1.1"
@@ -1753,30 +1736,14 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/hash": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.9.3.tgz",
-      "integrity": "sha512-qlH5B85XLzVAeijgKPjm1gQu35LoRYX/8igsjnN8vOlbc3O8BYAUIutU58fbHbtE8MJPbxQQUw7tkTjeoujcQQ==",
-      "dev": true,
-      "dependencies": {
-        "xxhash-wasm": "^0.4.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/@parcel/logger": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.9.3.tgz",
-      "integrity": "sha512-5FNBszcV6ilGFcijEOvoNVG6IUJGsnMiaEnGQs7Fvc1dktTjEddnoQbIYhcSZL63wEmzBZOgkT5yDMajJ/41jw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.12.0.tgz",
+      "integrity": "sha512-cJ7Paqa7/9VJ7C+KwgJlwMqTQBOjjn71FbKk0G07hydUEBISU2aDfmc/52o60ErL9l+vXB26zTrIBanbxS8rVg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/events": "2.9.3"
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/events": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -1787,9 +1754,9 @@
       }
     },
     "node_modules/@parcel/markdown-ansi": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.9.3.tgz",
-      "integrity": "sha512-/Q4X8F2aN8UNjAJrQ5NfK2OmZf6shry9DqetUSEndQ0fHonk78WKt6LT0zSKEBEW/bB/bXk6mNMsCup6L8ibjQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.12.0.tgz",
+      "integrity": "sha512-WZz3rzL8k0H3WR4qTHX6Ic8DlEs17keO9gtD4MNGyMNQbqQEvQ61lWJaIH0nAtgEetu0SOITiVqdZrb8zx/M7w==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0"
@@ -1803,18 +1770,18 @@
       }
     },
     "node_modules/@parcel/namer-default": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.9.3.tgz",
-      "integrity": "sha512-1ynFEcap48/Ngzwwn318eLYpLUwijuuZoXQPCsEQ21OOIOtfhFQJaPwXTsw6kRitshKq76P2aafE0BioGSqxcA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.12.0.tgz",
+      "integrity": "sha512-9DNKPDHWgMnMtqqZIMiEj/R9PNWW16lpnlHjwK3ciRlMPgjPJ8+UNc255teZODhX0T17GOzPdGbU/O/xbxVPzA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1822,15 +1789,16 @@
       }
     },
     "node_modules/@parcel/node-resolver-core": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.0.3.tgz",
-      "integrity": "sha512-AjxNcZVHHJoNT/A99PKIdFtwvoze8PAiC3yz8E/dRggrDIOboUEodeQYV5Aq++aK76uz/iOP0tST2T8A5rhb1A==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.3.0.tgz",
+      "integrity": "sha512-rhPW9DYPEIqQBSlYzz3S0AjXxjN6Ub2yS6tzzsW/4S3Gpsgk/uEq4ZfxPvoPf/6TgZndVxmKwpmxaKtGMmf3cA==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/fs": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1",
         "semver": "^7.5.2"
       },
@@ -1842,50 +1810,23 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/node-resolver-core/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@parcel/node-resolver-core/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@parcel/optimizer-css": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.9.3.tgz",
-      "integrity": "sha512-RK1QwcSdWDNUsFvuLy0hgnYKtPQebzCb0vPPzqs6LhL+vqUu9utOyRycGaQffHCkHVQP6zGlN+KFssd7YtFGhA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.12.0.tgz",
+      "integrity": "sha512-ifbcC97fRzpruTjaa8axIFeX4MjjSIlQfem3EJug3L2AVqQUXnM1XO8L0NaXGNLTW2qnh1ZjIJ7vXT/QhsphsA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.9.3",
+        "@parcel/utils": "2.12.0",
         "browserslist": "^4.6.6",
-        "lightningcss": "^1.16.1",
+        "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1893,12 +1834,12 @@
       }
     },
     "node_modules/@parcel/optimizer-htmlnano": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.9.3.tgz",
-      "integrity": "sha512-9g/KBck3c6DokmJfvJ5zpHFBiCSolaGrcsTGx8C3YPdCTVTI9P1TDCwUxvAr4LjpcIRSa82wlLCI+nF6sSgxKA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.12.0.tgz",
+      "integrity": "sha512-MfPMeCrT8FYiOrpFHVR+NcZQlXAptK2r4nGJjfT+ndPBhEEZp4yyL7n1y7HfX9geg5altc4WTb4Gug7rCoW8VQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
+        "@parcel/plugin": "2.12.0",
         "htmlnano": "^2.0.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
@@ -1906,7 +1847,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2043,42 +1984,43 @@
       }
     },
     "node_modules/@parcel/optimizer-image": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.9.3.tgz",
-      "integrity": "sha512-530YzthE7kmecnNhPbkAK+26yQNt69pfJrgE0Ev0BZaM1Wu2+33nki7o8qvkTkikhPrurEJLGIXt1qKmbKvCbA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.12.0.tgz",
+      "integrity": "sha512-bo1O7raeAIbRU5nmNVtx8divLW9Xqn0c57GVNGeAK4mygnQoqHqRZ0mR9uboh64pxv6ijXZHPhKvU9HEpjPjBQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
-        "@parcel/workers": "2.9.3"
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.9.3"
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@parcel/optimizer-svgo": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.9.3.tgz",
-      "integrity": "sha512-ytQS0wY5JJhWU4mL0wfhYDUuHcfuw+Gy2+JcnTm1t1AZXHlOTbU6EzRWNqBShsgXjvdrQQXizAe3B6GFFlFJVQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.12.0.tgz",
+      "integrity": "sha512-Kyli+ZZXnoonnbeRQdoWwee9Bk2jm/49xvnfb+2OO8NN0d41lblBoRhOyFiScRnJrw7eVl1Xrz7NTkXCIO7XFQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "svgo": "^2.4.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2215,21 +2157,21 @@
       }
     },
     "node_modules/@parcel/optimizer-swc": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.9.3.tgz",
-      "integrity": "sha512-GQINNeqtdpL1ombq/Cpwi6IBk02wKJ/JJbYbyfHtk8lxlq13soenpwOlzJ5T9D2fdG+FUhai9NxpN5Ss4lNoAg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.12.0.tgz",
+      "integrity": "sha512-iBi6LZB3lm6WmbXfzi8J3DCVPmn4FN2lw7DGXxUXu7MouDPVWfTsM6U/5TkSHJRNRogZ2gqy5q9g34NPxHbJcw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.9.3",
+        "@parcel/utils": "2.12.0",
         "@swc/core": "^1.3.36",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2237,18 +2179,19 @@
       }
     },
     "node_modules/@parcel/package-manager": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.9.3.tgz",
-      "integrity": "sha512-NH6omcNTEupDmW4Lm1e4NUYBjdqkURxgZ4CNESESInHJe6tblVhNB8Rpr1ar7zDar7cly9ILr8P6N3Ei7bTEjg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.12.0.tgz",
+      "integrity": "sha512-0nvAezcjPx9FT+hIL+LS1jb0aohwLZXct7jAh7i0MLMtehOi0z1Sau+QpgMlA9rfEZZ1LIeFdnZZwqSy7Ccspw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/fs": "2.9.3",
-        "@parcel/logger": "2.9.3",
-        "@parcel/node-resolver-core": "3.0.3",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
-        "@parcel/workers": "2.9.3",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/node-resolver-core": "3.3.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0",
+        "@swc/core": "^1.3.36",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -2259,51 +2202,25 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.9.3"
-      }
-    },
-    "node_modules/@parcel/package-manager/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@parcel/package-manager/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@parcel/packager-css": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.9.3.tgz",
-      "integrity": "sha512-mePiWiYZOULY6e1RdAIJyRoYqXqGci0srOaVZYaP7mnrzvJgA63kaZFFsDiEWghunQpMUuUjM2x/vQVHzxmhKQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.12.0.tgz",
+      "integrity": "sha512-j3a/ODciaNKD19IYdWJT+TP+tnhhn5koBGBWWtrKSu0UxWpnezIGZetit3eE+Y9+NTePalMkvpIlit2eDhvfJA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.9.3",
+        "@parcel/utils": "2.12.0",
+        "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2311,20 +2228,20 @@
       }
     },
     "node_modules/@parcel/packager-html": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.9.3.tgz",
-      "integrity": "sha512-0Ex+O0EaZf9APNERRNGgGto02hFJ6f5RQEvRWBK55WAV1rXeU+kpjC0c0qZvnUaUtXfpWMsEBkevJCwDkUMeMg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.12.0.tgz",
+      "integrity": "sha512-PpvGB9hFFe+19NXGz2ApvPrkA9GwEqaDAninT+3pJD57OVBaxB8U+HN4a5LICKxjUppPPqmrLb6YPbD65IX4RA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2332,22 +2249,23 @@
       }
     },
     "node_modules/@parcel/packager-js": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.9.3.tgz",
-      "integrity": "sha512-V5xwkoE3zQ3R+WqAWhA1KGQ791FvJeW6KonOlMI1q76Djjgox68hhObqcLu66AmYNhR2R/wUpkP18hP2z8dSFw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.12.0.tgz",
+      "integrity": "sha512-viMF+FszITRRr8+2iJyk+4ruGiL27Y6AF7hQ3xbJfzqnmbOhGFtLTQwuwhOLqN/mWR2VKdgbLpZSarWaO3yAMg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.9.3",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "globals": "^13.2.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2355,16 +2273,16 @@
       }
     },
     "node_modules/@parcel/packager-raw": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.9.3.tgz",
-      "integrity": "sha512-oPQTNoYanQ2DdJyL61uPYK2py83rKOT8YVh2QWAx0zsSli6Kiy64U3+xOCYWgDVCrHw9+9NpQMuAdSiFg4cq8g==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.12.0.tgz",
+      "integrity": "sha512-tJZqFbHqP24aq1F+OojFbQIc09P/u8HAW5xfndCrFnXpW4wTgM3p03P0xfw3gnNq+TtxHJ8c3UFE5LnXNNKhYA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3"
+        "@parcel/plugin": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2372,19 +2290,36 @@
       }
     },
     "node_modules/@parcel/packager-svg": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.9.3.tgz",
-      "integrity": "sha512-p/Ya6UO9DAkaCUFxfFGyeHZDp9YPAlpdnh1OChuwqSFOXFjjeXuoK4KLT+ZRalVBo2Jo8xF70oKMZw4MVvaL7Q==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.12.0.tgz",
+      "integrity": "sha512-ldaGiacGb2lLqcXas97k8JiZRbAnNREmcvoY2W2dvW4loVuDT9B9fU777mbV6zODpcgcHWsLL3lYbJ5Lt3y9cg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "posthtml": "^0.16.4"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/packager-wasm": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.12.0.tgz",
+      "integrity": "sha512-fYqZzIqO9fGYveeImzF8ll6KRo2LrOXfD+2Y5U3BiX/wp9wv17dz50QLDQm9hmTcKGWxK4yWqKQh+Evp/fae7A==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.12.0"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2392,12 +2327,12 @@
       }
     },
     "node_modules/@parcel/plugin": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.9.3.tgz",
-      "integrity": "sha512-qN85Gqr2GMuxX1dT1mnuO9hOcvlEv1lrYrCxn7CJN2nUhbwcfG+LEvcrCzCOJ6XtIHm+ZBV9h9p7FfoPLvpw+g==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.12.0.tgz",
+      "integrity": "sha512-nc/uRA8DiMoe4neBbzV6kDndh/58a4wQuGKw5oEoIwBCHUvE2W8ZFSu7ollSXUGRzfacTt4NdY8TwS73ScWZ+g==",
       "dev": true,
       "dependencies": {
-        "@parcel/types": "2.9.3"
+        "@parcel/types": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -2408,13 +2343,13 @@
       }
     },
     "node_modules/@parcel/profiler": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.9.3.tgz",
-      "integrity": "sha512-pyHc9lw8VZDfgZoeZWZU9J0CVEv1Zw9O5+e0DJPDPHuXJYr72ZAOhbljtU3owWKAeW+++Q2AZWkbUGEOjI/e6g==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.12.0.tgz",
+      "integrity": "sha512-q53fvl5LDcFYzMUtSusUBZSjQrKjMlLEBgKeQHFwkimwR1mgoseaDBDuNz0XvmzDzF1UelJ02TUKCGacU8W2qA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/events": "2.9.3",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/events": "2.12.0",
         "chrome-trace-event": "^1.0.2"
       },
       "engines": {
@@ -2426,20 +2361,20 @@
       }
     },
     "node_modules/@parcel/reporter-cli": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.9.3.tgz",
-      "integrity": "sha512-pZiEvQpuXFuQBafMHxkDmwH8CnnK9sWHwa3bSbsnt385aUahtE8dpY0LKt+K1zfB6degKoczN6aWVj9WycQuZQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.12.0.tgz",
+      "integrity": "sha512-TqKsH4GVOLPSCanZ6tcTPj+rdVHERnt5y4bwTM82cajM21bCX1Ruwp8xOKU+03091oV2pv5ieB18pJyRF7IpIw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "chalk": "^4.1.0",
         "term-size": "^2.2.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2447,17 +2382,17 @@
       }
     },
     "node_modules/@parcel/reporter-dev-server": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.9.3.tgz",
-      "integrity": "sha512-s6eboxdLEtRSvG52xi9IiNbcPKC0XMVmvTckieue2EqGDbDcaHQoHmmwkk0rNq0/Z/UxelGcQXoIYC/0xq3ykQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.12.0.tgz",
+      "integrity": "sha512-tIcDqRvAPAttRlTV28dHcbWT5K2r/MBFks7nM4nrEDHWtnrCwimkDmZTc1kD8QOCCjGVwRHcQybpHvxfwol6GA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3"
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2465,19 +2400,19 @@
       }
     },
     "node_modules/@parcel/reporter-tracer": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.9.3.tgz",
-      "integrity": "sha512-9cXpKWk0m6d6d+4+TlAdOe8XIPaFEIKGWMWG+5SFAQE08u3olet4PSvd49F4+ZZo5ftRE7YI3j6xNbXvJT8KGw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.12.0.tgz",
+      "integrity": "sha512-g8rlu9GxB8Ut/F8WGx4zidIPQ4pcYFjU9bZO+fyRIPrSUFH2bKijCnbZcr4ntqzDGx74hwD6cCG4DBoleq2UlQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "chrome-trace-event": "^1.0.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2485,17 +2420,17 @@
       }
     },
     "node_modules/@parcel/resolver-default": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.9.3.tgz",
-      "integrity": "sha512-8ESJk1COKvDzkmOnppNXoDamNMlYVIvrKc2RuFPmp8nKVj47R6NwMgvwxEaatyPzvkmyTpq5RvG9I3HFc+r4Cw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.12.0.tgz",
+      "integrity": "sha512-uuhbajTax37TwCxu7V98JtRLiT6hzE4VYSu5B7Qkauy14/WFt2dz6GOUXPgVsED569/hkxebPx3KCMtZW6cHHA==",
       "dev": true,
       "dependencies": {
-        "@parcel/node-resolver-core": "3.0.3",
-        "@parcel/plugin": "2.9.3"
+        "@parcel/node-resolver-core": "3.3.0",
+        "@parcel/plugin": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2503,17 +2438,17 @@
       }
     },
     "node_modules/@parcel/runtime-browser-hmr": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.9.3.tgz",
-      "integrity": "sha512-EgiDIDrVAWpz7bOzWXqVinQkaFjLwT34wsonpXAbuI7f7r00d52vNAQC9AMu+pTijA3gyKoJ+Q4NWPMZf7ACDA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.12.0.tgz",
+      "integrity": "sha512-4ZLp2FWyD32r0GlTulO3+jxgsA3oO1P1b5oO2IWuWilfhcJH5LTiazpL5YdusUjtNn9PGN6QLAWfxmzRIfM+Ow==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3"
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2521,19 +2456,19 @@
       }
     },
     "node_modules/@parcel/runtime-js": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.9.3.tgz",
-      "integrity": "sha512-EvIy+qXcKnB5qxHhe96zmJpSAViNVXHfQI5RSdZ2a7CPwORwhTI+zPNT9sb7xb/WwFw/WuTTgzT40b41DceU6Q==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.12.0.tgz",
+      "integrity": "sha512-sBerP32Z1crX5PfLNGDSXSdqzlllM++GVnVQVeM7DgMKS8JIFG3VLi28YkX+dYYGtPypm01JoIHCkvwiZEcQJg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2541,19 +2476,19 @@
       }
     },
     "node_modules/@parcel/runtime-react-refresh": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.9.3.tgz",
-      "integrity": "sha512-XBgryZQIyCmi6JwEfMUCmINB3l1TpTp9a2iFxmYNpzHlqj4Ve0saKaqWOVRLvC945ZovWIBzcSW2IYqWKGtbAA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.12.0.tgz",
+      "integrity": "sha512-SCHkcczJIDFTFdLTzrHTkQ0aTrX3xH6jrA4UsCBL6ji61+w+ohy4jEEe9qCgJVXhnJfGLE43HNXek+0MStX+Mw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "react-error-overlay": "6.0.9",
         "react-refresh": "^0.9.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2561,18 +2496,31 @@
       }
     },
     "node_modules/@parcel/runtime-service-worker": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.9.3.tgz",
-      "integrity": "sha512-qLJLqv1mMdWL7gyh8aKBFFAuEiJkhUUgLKpdn6eSfH/R7kTtb76WnOwqUrhvEI9bZFUM/8Pa1bzJnPpqSOM+Sw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.12.0.tgz",
+      "integrity": "sha512-BXuMBsfiwpIEnssn+jqfC3jkgbS8oxeo3C7xhSQsuSv+AF2FwY3O3AO1c1RBskEW3XrBLNINOJujroNw80VTKA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/rust": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.12.0.tgz",
+      "integrity": "sha512-005cldMdFZFDPOjbDVEXcINQ3wT4vrxvSavRWI3Az0e3E18exO/x/mW9f648KtXugOXMAqCEqhFHcXECL9nmMw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2592,15 +2540,15 @@
       }
     },
     "node_modules/@parcel/transformer-babel": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.9.3.tgz",
-      "integrity": "sha512-pURtEsnsp3h6tOBDuzh9wRvVtw4PgIlqwAArIWdrG7iwqOUYv9D8ME4+ePWEu7MQWAp58hv9pTJtqWv4T+Sq8A==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.12.0.tgz",
+      "integrity": "sha512-zQaBfOnf/l8rPxYGnsk/ufh/0EuqvmnxafjBIpKZ//j6rGylw5JCqXSb1QvvAqRYruKeccxGv7+HrxpqKU6V4A==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.9.3",
+        "@parcel/utils": "2.12.0",
         "browserslist": "^4.6.6",
         "json5": "^2.2.0",
         "nullthrows": "^1.1.1",
@@ -2608,7 +2556,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2627,50 +2575,23 @@
         "node": ">=6"
       }
     },
-    "node_modules/@parcel/transformer-babel/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@parcel/transformer-babel/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@parcel/transformer-css": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.9.3.tgz",
-      "integrity": "sha512-duWMdbEBBPjg3fQdXF16iWIdThetDZvCs2TpUD7xOlXH6kR0V5BJy8ONFT15u1RCqIV9hSNGaS3v3I9YRNY5zQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.12.0.tgz",
+      "integrity": "sha512-vXhOqoAlQGATYyQ433Z1DXKmiKmzOAUmKysbYH3FD+LKEKLMEl/pA14goqp00TW+A/EjtSKKyeMyHlMIIUqj4Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.9.3",
+        "@parcel/utils": "2.12.0",
         "browserslist": "^4.6.6",
-        "lightningcss": "^1.16.1",
+        "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2678,14 +2599,14 @@
       }
     },
     "node_modules/@parcel/transformer-html": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.9.3.tgz",
-      "integrity": "sha512-0NU4omcHzFXA1seqftAXA2KNZaMByoKaNdXnLgBgtCGDiYvOcL+6xGHgY6pw9LvOh5um10KI5TxSIMILoI7VtA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.12.0.tgz",
+      "integrity": "sha512-5jW4dFFBlYBvIQk4nrH62rfA/G/KzVzEDa6S+Nne0xXhglLjkm64Ci9b/d4tKZfuGWUbpm2ASAq8skti/nfpXw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -2695,70 +2616,56 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/transformer-html/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+    "node_modules/@parcel/transformer-html/node_modules/srcset": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/srcset/-/srcset-4.0.0.tgz",
+      "integrity": "sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==",
       "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@parcel/transformer-html/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
+        "node": ">=12"
       },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@parcel/transformer-image": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.9.3.tgz",
-      "integrity": "sha512-7CEe35RaPadQzLIuxzTtIxnItvOoy46hcbXtOdDt6lmVa4omuOygZYRIya2lsGIP4JHvAaALMb5nt99a1uTwJg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.12.0.tgz",
+      "integrity": "sha512-8hXrGm2IRII49R7lZ0RpmNk27EhcsH+uNKsvxuMpXPuEnWgC/ha/IrjaI29xCng1uGur74bJF43NUSQhR4aTdw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
-        "@parcel/workers": "2.9.3",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.9.3"
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@parcel/transformer-js": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.9.3.tgz",
-      "integrity": "sha512-Z2MVVg5FYcPOfxlUwxqb5l9yjTMEqE3KI3zq2MBRUme6AV07KxLmCDF23b6glzZlHWQUE8MXzYCTAkOPCcPz+Q==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.12.0.tgz",
+      "integrity": "sha512-OSZpOu+FGDbC/xivu24v092D9w6EGytB3vidwbdiJ2FaPgfV7rxS0WIUjH4I0OcvHAcitArRXL0a3+HrNTdQQw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.9.3",
-        "@parcel/workers": "2.9.3",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0",
         "@swc/helpers": "^0.5.0",
         "browserslist": "^4.6.6",
         "nullthrows": "^1.1.1",
@@ -2767,55 +2674,28 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.9.3"
-      }
-    },
-    "node_modules/@parcel/transformer-js/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@parcel/transformer-js/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@parcel/transformer-json": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.9.3.tgz",
-      "integrity": "sha512-yNL27dbOLhkkrjaQjiQ7Im9VOxmkfuuSNSmS0rA3gEjVcm07SLKRzWkAaPnyx44Lb6bzyOTWwVrb9aMmxgADpA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.12.0.tgz",
+      "integrity": "sha512-Utv64GLRCQILK5r0KFs4o7I41ixMPllwOLOhkdjJKvf1hZmN6WqfOmB1YLbWS/y5Zb/iB52DU2pWZm96vLFQZQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
+        "@parcel/plugin": "2.12.0",
         "json5": "^2.2.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2835,15 +2715,15 @@
       }
     },
     "node_modules/@parcel/transformer-postcss": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.9.3.tgz",
-      "integrity": "sha512-HoDvPqKzhpmvMmHqQhDnt8F1vH61m6plpGiYaYnYv2Om4HHi5ZIq9bO+9QLBnTKfaZ7ndYSefTKOxTYElg7wyw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.12.0.tgz",
+      "integrity": "sha512-FZqn+oUtiLfPOn67EZxPpBkfdFiTnF4iwiXPqvst3XI8H+iC+yNgzmtJkunOOuylpYY6NOU5jT8d7saqWSDv2Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "clone": "^2.1.1",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
@@ -2851,7 +2731,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2867,41 +2747,14 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/@parcel/transformer-postcss/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@parcel/transformer-postcss/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@parcel/transformer-posthtml": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.9.3.tgz",
-      "integrity": "sha512-2fQGgrzRmaqbWf3y2/T6xhqrNjzqMMKksqJzvc8TMfK6f2kg3Ddjv158eaSW2JdkV39aY7tvAOn5f1uzo74BMA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.12.0.tgz",
+      "integrity": "sha512-z6Z7rav/pcaWdeD+2sDUcd0mmNZRUvtHaUGa50Y2mr+poxrKilpsnFMSiWBT+oOqPt7j71jzDvrdnAF4XkCljg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -2910,51 +2763,24 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/transformer-posthtml/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@parcel/transformer-posthtml/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@parcel/transformer-raw": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.9.3.tgz",
-      "integrity": "sha512-oqdPzMC9QzWRbY9J6TZEqltknjno+dY24QWqf8ondmdF2+W+/2mRDu59hhCzQrqUHgTq4FewowRZmSfpzHxwaQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.12.0.tgz",
+      "integrity": "sha512-Ht1fQvXxix0NncdnmnXZsa6hra20RXYh1VqhBYZLsDfkvGGFnXIgO03Jqn4Z8MkKoa0tiNbDhpKIeTjyclbBxQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3"
+        "@parcel/plugin": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2962,18 +2788,18 @@
       }
     },
     "node_modules/@parcel/transformer-react-refresh-wrap": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.9.3.tgz",
-      "integrity": "sha512-cb9NyU6oJlDblFIlzqIE8AkvRQVGl2IwJNKwD4PdE7Y6sq2okGEPG4hOw3k/Y9JVjM4/2pUORqvjSRhWwd9oVQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.12.0.tgz",
+      "integrity": "sha512-GE8gmP2AZtkpBIV5vSCVhewgOFRhqwdM5Q9jNPOY5PKcM3/Ff0qCqDiTzzGLhk0/VMBrdjssrfZkVx6S/lHdJw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "react-refresh": "^0.9.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2981,14 +2807,14 @@
       }
     },
     "node_modules/@parcel/transformer-svg": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.9.3.tgz",
-      "integrity": "sha512-ypmE+dzB09IMCdEAkOsSxq1dEIm2A3h67nAFz4qbfHbwNgXBUuy/jB3ZMwXN/cO0f7SBh/Ap8Jhq6vmGqB5tWw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.12.0.tgz",
+      "integrity": "sha512-cZJqGRJ4JNdYcb+vj94J7PdOuTnwyy45dM9xqbIMH+HSiiIkfrMsdEwYft0GTyFTdsnf+hdHn3tau7Qa5hhX+A==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -2997,66 +2823,39 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/transformer-svg/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@parcel/transformer-svg/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@parcel/types": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.9.3.tgz",
-      "integrity": "sha512-NSNY8sYtRhvF1SqhnIGgGvJocyWt1K8Tnw5cVepm0g38ywtX6mwkBvMkmeehXkII4mSUn+frD9wGsydTunezvA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-8zAFiYNCwNTQcglIObyNwKfRYQK5ELlL13GuBOrSMxueUiI5ylgsGbTS1N7J3dAGZixHO8KhHGv5a71FILn9rQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/cache": "2.9.3",
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/fs": "2.9.3",
-        "@parcel/package-manager": "2.9.3",
+        "@parcel/cache": "2.12.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/package-manager": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/workers": "2.9.3",
+        "@parcel/workers": "2.12.0",
         "utility-types": "^3.10.0"
       }
     },
     "node_modules/@parcel/utils": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.9.3.tgz",
-      "integrity": "sha512-cesanjtj/oLehW8Waq9JFPmAImhoiHX03ihc3JTWkrvJYSbD7wYKCDgPAM3JiRAqvh1LZ6P699uITrYWNoRLUg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.12.0.tgz",
+      "integrity": "sha512-z1JhLuZ8QmDaYoEIuUCVZlhcFrS7LMfHrb2OCRui5SQFntRWBH2fNM6H/fXXUkT9SkxcuFP2DUA6/m4+Gkz72g==",
       "dev": true,
       "dependencies": {
-        "@parcel/codeframe": "2.9.3",
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/logger": "2.9.3",
-        "@parcel/markdown-ansi": "2.9.3",
+        "@parcel/codeframe": "2.12.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/markdown-ansi": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "@parcel/source-map": "^2.1.1",
         "chalk": "^4.1.0",
         "nullthrows": "^1.1.1"
@@ -3070,11 +2869,10 @@
       }
     },
     "node_modules/@parcel/watcher": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.2.0.tgz",
-      "integrity": "sha512-71S4TF+IMyAn24PK4KSkdKtqJDR3zRzb0HE3yXpacItqTM7XfF2f5q9NEGLEVl0dAaBAGfNwDCjH120y25F6Tg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.4.1.tgz",
+      "integrity": "sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==",
       "dev": true,
-      "hasInstallScript": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
         "is-glob": "^4.0.3",
@@ -3089,22 +2887,24 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "@parcel/watcher-android-arm64": "2.2.0",
-        "@parcel/watcher-darwin-arm64": "2.2.0",
-        "@parcel/watcher-darwin-x64": "2.2.0",
-        "@parcel/watcher-linux-arm-glibc": "2.2.0",
-        "@parcel/watcher-linux-arm64-glibc": "2.2.0",
-        "@parcel/watcher-linux-arm64-musl": "2.2.0",
-        "@parcel/watcher-linux-x64-glibc": "2.2.0",
-        "@parcel/watcher-linux-x64-musl": "2.2.0",
-        "@parcel/watcher-win32-arm64": "2.2.0",
-        "@parcel/watcher-win32-x64": "2.2.0"
+        "@parcel/watcher-android-arm64": "2.4.1",
+        "@parcel/watcher-darwin-arm64": "2.4.1",
+        "@parcel/watcher-darwin-x64": "2.4.1",
+        "@parcel/watcher-freebsd-x64": "2.4.1",
+        "@parcel/watcher-linux-arm-glibc": "2.4.1",
+        "@parcel/watcher-linux-arm64-glibc": "2.4.1",
+        "@parcel/watcher-linux-arm64-musl": "2.4.1",
+        "@parcel/watcher-linux-x64-glibc": "2.4.1",
+        "@parcel/watcher-linux-x64-musl": "2.4.1",
+        "@parcel/watcher-win32-arm64": "2.4.1",
+        "@parcel/watcher-win32-ia32": "2.4.1",
+        "@parcel/watcher-win32-x64": "2.4.1"
       }
     },
     "node_modules/@parcel/watcher-android-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.2.0.tgz",
-      "integrity": "sha512-nU2wh00CTQT9rr1TIKTjdQ9lAGYpmz6XuKw0nAwAN+S2A5YiD55BK1u+E5WMCT8YOIDe/n6gaj4o/Bi9294SSQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.4.1.tgz",
+      "integrity": "sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==",
       "cpu": [
         "arm64"
       ],
@@ -3122,9 +2922,9 @@
       }
     },
     "node_modules/@parcel/watcher-darwin-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.2.0.tgz",
-      "integrity": "sha512-cJl0UZDcodciy3TDMomoK/Huxpjlkkim3SyMgWzjovHGOZKNce9guLz2dzuFwfObBFCjfznbFMIvAZ5syXotYw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.4.1.tgz",
+      "integrity": "sha512-ln41eihm5YXIY043vBrrHfn94SIBlqOWmoROhsMVTSXGh0QahKGy77tfEywQ7v3NywyxBBkGIfrWRHm0hsKtzA==",
       "cpu": [
         "arm64"
       ],
@@ -3142,9 +2942,9 @@
       }
     },
     "node_modules/@parcel/watcher-darwin-x64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.2.0.tgz",
-      "integrity": "sha512-QI77zxaGrCV1StKcoRYfsUfmUmvPMPfQrubkBBy5XujV2fwaLgZivQOTQMBgp5K2+E19u1ufpspKXAPqSzpbyg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.4.1.tgz",
+      "integrity": "sha512-yrw81BRLjjtHyDu7J61oPuSoeYWR3lDElcPGJyOvIXmor6DEo7/G2u1o7I38cwlcoBHQFULqF6nesIX3tsEXMg==",
       "cpu": [
         "x64"
       ],
@@ -3161,10 +2961,30 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.4.1.tgz",
+      "integrity": "sha512-TJa3Pex/gX3CWIx/Co8k+ykNdDCLx+TuZj3f3h7eOjgpdKM+Mnix37RYsYU4LHhiYJz3DK5nFCCra81p6g050w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@parcel/watcher-linux-arm-glibc": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.2.0.tgz",
-      "integrity": "sha512-I2GPBcAXazPzabCmfsa3HRRW+MGlqxYd8g8RIueJU+a4o5nyNZDz0CR1cu0INT0QSQXEZV7w6UE8Hz9CF8u3Pg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.4.1.tgz",
+      "integrity": "sha512-4rVYDlsMEYfa537BRXxJ5UF4ddNwnr2/1O4MHM5PjI9cvV2qymvhwZSFgXqbS8YoTk5i/JR0L0JDs69BUn45YA==",
       "cpu": [
         "arm"
       ],
@@ -3182,9 +3002,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-arm64-glibc": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.2.0.tgz",
-      "integrity": "sha512-St5mlfp+2lS9AmgixUqfwJa/DwVmTCJxC1HcOubUTz6YFOKIlkHCeUa1Bxi4E/tR/HSez8+heXHL8HQkJ4Bd8g==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.4.1.tgz",
+      "integrity": "sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==",
       "cpu": [
         "arm64"
       ],
@@ -3202,9 +3022,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-arm64-musl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.2.0.tgz",
-      "integrity": "sha512-jS+qfhhoOBVWwMLP65MaG8xdInMK30pPW8wqTCg2AAuVJh5xepMbzkhHJ4zURqHiyY3EiIRuYu4ONJKCxt8iqA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.4.1.tgz",
+      "integrity": "sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==",
       "cpu": [
         "arm64"
       ],
@@ -3222,9 +3042,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-x64-glibc": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.2.0.tgz",
-      "integrity": "sha512-xJvJ7R2wJdi47WZBFS691RDOWvP1j/IAs3EXaWVhDI8FFITbWrWaln7KoNcR0Y3T+ZwimFY/cfb0PNht1q895g==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.4.1.tgz",
+      "integrity": "sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==",
       "cpu": [
         "x64"
       ],
@@ -3242,9 +3062,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-x64-musl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.2.0.tgz",
-      "integrity": "sha512-D+NMpgr23a+RI5mu8ZPKWy7AqjBOkURFDgP5iIXXEf/K3hm0jJ3ogzi0Ed2237B/CdYREimCgXyeiAlE/FtwyA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.4.1.tgz",
+      "integrity": "sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==",
       "cpu": [
         "x64"
       ],
@@ -3262,9 +3082,9 @@
       }
     },
     "node_modules/@parcel/watcher-win32-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.2.0.tgz",
-      "integrity": "sha512-z225cPn3aygJsyVUOWwfyW+fY0Tvk7N3XCOl66qUPFxpbuXeZuiuuJemmtm8vxyqa3Ur7peU/qJxrpC64aeI7Q==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.4.1.tgz",
+      "integrity": "sha512-Uq2BPp5GWhrq/lcuItCHoqxjULU1QYEcyjSO5jqqOK8RNFDBQnenMMx4gAl3v8GiWa59E9+uDM7yZ6LxwUIfRg==",
       "cpu": [
         "arm64"
       ],
@@ -3281,10 +3101,30 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.4.1.tgz",
+      "integrity": "sha512-maNRit5QQV2kgHFSYwftmPBxiuK5u4DXjbXx7q6eKjq5dsLXZ4FJiVvlcw35QXzk0KrUecJmuVFbj4uV9oYrcw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@parcel/watcher-win32-x64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.2.0.tgz",
-      "integrity": "sha512-JqGW0RJ61BkKx+yYzIURt9s53P7xMVbv0uxYPzAXLBINGaFmkIKSuUPyBVfy8TMbvp93lvF4SPBNDzVRJfvgOw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.4.1.tgz",
+      "integrity": "sha512-+DvS92F9ezicfswqrvIRM2njcYJbd5mb9CUgtrHCHmvn7pPPa+nMDRu1o1bYYz/l5IB2NVGNJWiH7h1E58IF2A==",
       "cpu": [
         "x64"
       ],
@@ -3302,16 +3142,16 @@
       }
     },
     "node_modules/@parcel/workers": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.9.3.tgz",
-      "integrity": "sha512-zRrDuZJzTevrrwElYosFztgldhqW6G9q5zOeQXfVQFkkEJCNfg36ixeiofKRU8uu2x+j+T6216mhMNB6HiuY+w==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.12.0.tgz",
+      "integrity": "sha512-zv5We5Jmb+ZWXlU6A+AufyjY4oZckkxsZ8J4dvyWL0W8IQvGO1JB4FGeryyttzQv3RM3OxcN/BpTGPiDG6keBw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/logger": "2.9.3",
-        "@parcel/profiler": "2.9.3",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/profiler": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -3322,7 +3162,17 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.9.3"
+        "@parcel/core": "^2.12.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@pkgr/utils": {
@@ -3429,11 +3279,15 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.3.72",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.72.tgz",
-      "integrity": "sha512-+AKjwLH3/STfPrd7CHzB9+NG1FVT0UKJMUChuWq9sQ8b9xlV8vUeRgZXgh/EHYvNQgl/OUTQKtL6xU2yOLuEuA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.5.3.tgz",
+      "integrity": "sha512-pSEglypnBGLHBoBcv3aYS7IM2t2LRinubYMyP88UoFIcD2pear2CeB15CbjJ2IzuvERD0ZL/bthM7cDSR9g+aQ==",
       "dev": true,
       "hasInstallScript": true,
+      "dependencies": {
+        "@swc/counter": "^0.1.2",
+        "@swc/types": "^0.1.5"
+      },
       "engines": {
         "node": ">=10"
       },
@@ -3442,16 +3296,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.3.72",
-        "@swc/core-darwin-x64": "1.3.72",
-        "@swc/core-linux-arm-gnueabihf": "1.3.72",
-        "@swc/core-linux-arm64-gnu": "1.3.72",
-        "@swc/core-linux-arm64-musl": "1.3.72",
-        "@swc/core-linux-x64-gnu": "1.3.72",
-        "@swc/core-linux-x64-musl": "1.3.72",
-        "@swc/core-win32-arm64-msvc": "1.3.72",
-        "@swc/core-win32-ia32-msvc": "1.3.72",
-        "@swc/core-win32-x64-msvc": "1.3.72"
+        "@swc/core-darwin-arm64": "1.5.3",
+        "@swc/core-darwin-x64": "1.5.3",
+        "@swc/core-linux-arm-gnueabihf": "1.5.3",
+        "@swc/core-linux-arm64-gnu": "1.5.3",
+        "@swc/core-linux-arm64-musl": "1.5.3",
+        "@swc/core-linux-x64-gnu": "1.5.3",
+        "@swc/core-linux-x64-musl": "1.5.3",
+        "@swc/core-win32-arm64-msvc": "1.5.3",
+        "@swc/core-win32-ia32-msvc": "1.5.3",
+        "@swc/core-win32-x64-msvc": "1.5.3"
       },
       "peerDependencies": {
         "@swc/helpers": "^0.5.0"
@@ -3463,9 +3317,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.3.72",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.72.tgz",
-      "integrity": "sha512-oNSI5hVfZ+1xpj+dH1g4kQqA0VsGtqd8S9S+cDqkHZiOOVOevw9KN6dzVtmLOcPtlULVypVc0TVvsB55KdVZhQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.5.3.tgz",
+      "integrity": "sha512-kRmmV2XqWegzGXvJfVVOj10OXhLgaVOOBjaX3p3Aqg7Do5ksg+bY5wi1gAN/Eul7B08Oqf7GG7WJevjDQGWPOg==",
       "cpu": [
         "arm64"
       ],
@@ -3479,9 +3333,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.3.72",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.72.tgz",
-      "integrity": "sha512-y5O/WQ1g0/VfTgeNahWIOutbdD5U2Gi703jaefdcoJo3FUx8WU108QQdbVGwGMgaqapo3iQB6Qs9paixYQAYsA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.5.3.tgz",
+      "integrity": "sha512-EYs0+ovaRw6ZN9GBr2nIeC7gUXWA0q4RYR+Og3Vo0Qgv2Mt/XudF44A2lPK9X7M3JIfu6JjnxnTuvsK1Lqojfw==",
       "cpu": [
         "x64"
       ],
@@ -3495,9 +3349,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.3.72",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.72.tgz",
-      "integrity": "sha512-05JdWcso0OomHF+7bk5MBDgI8MZ9skcQ/4nhSv5gboSgSiuBmKM15Bg3lZ5iAUwGByNj7pGkSmmd3YwTrXEB+g==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.5.3.tgz",
+      "integrity": "sha512-RBVUTidSf4wgPdv98VrgJ4rMzMDN/3LBWdT7l+R7mNFH+mtID7ZAhTON0o/m1HkECgAgi1xcbTOVAw1xgd5KLA==",
       "cpu": [
         "arm"
       ],
@@ -3511,9 +3365,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.3.72",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.72.tgz",
-      "integrity": "sha512-8qRELJaeYshhJgqvyOeXCKqBOpai+JYdWuouMbvvDUL85j3OcZhzR+bipexEbbJKcOCdRnoYB7Qg6mjqZ0t7VA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.5.3.tgz",
+      "integrity": "sha512-DCC6El3MiTYfv98CShxz/g2s4Pxn6tV0mldCQ0UdRqaN2ApUn7E+zTrqaj5bk7yII3A43WhE9Mr6wNPbXUeVyg==",
       "cpu": [
         "arm64"
       ],
@@ -3527,9 +3381,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.3.72",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.72.tgz",
-      "integrity": "sha512-tOqAGZw+Pe7YrBHFrwFVyRiKqjgjzwYbJmY+UDxLrzWrZSVtC3eO2TPrp7kWmhirg40Og81BbdfRAl8ds48w0Q==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.5.3.tgz",
+      "integrity": "sha512-p04ysjYXEyaCGpJvwHm0T0nkPawXtdKBTThWnlh8M5jYULVNVA1YmC9azG2Avs1GDaLgBPVUgodmFYpdSupOYA==",
       "cpu": [
         "arm64"
       ],
@@ -3543,9 +3397,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.3.72",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.72.tgz",
-      "integrity": "sha512-U2W2xWR3s9nplGVWz376GiBlcLTgxyYKlpZPBNZk0w3OvTcjKC62gW1Pe7PUkk4NgJUnaQDBa/mb4V4Zl+GZPA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.5.3.tgz",
+      "integrity": "sha512-/l4KJu0xwYm6tcVSOvF8RbXrIeIHJAhWnKvuX4ZnYKFkON968kB8Ghx+1yqBQcZf36tMzSuZUC5xBUA9u66lGA==",
       "cpu": [
         "x64"
       ],
@@ -3559,9 +3413,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.3.72",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.72.tgz",
-      "integrity": "sha512-3+2dUiZBsifKgvnFEHWdysXjInK8K+BfPBw2tTZJmq1+fZLt0rvuErYDVMLfIJnVWLCcJMnDtTXrvkFV1y/6iA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.5.3.tgz",
+      "integrity": "sha512-54DmSnrTXq4fYEKNR0nFAImG3+FxsHlQ6Tol/v3l+rxmg2K0FeeDOpH7wTXeWhMGhFlGrLIyLSnA+SzabfoDIA==",
       "cpu": [
         "x64"
       ],
@@ -3575,9 +3429,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.3.72",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.72.tgz",
-      "integrity": "sha512-ndI8xZ2AId806D25xgqw2SFJ9gc/jhg21+5hA8XPq9ZL+oDiaYDztaP3ijVmZ1G5xXKD9DpgB7xmylv/f6o6GA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.5.3.tgz",
+      "integrity": "sha512-piUMqoHNwDXChBfaaFIMzYgoxepfd8Ci1uXXNVEnuiRKz3FiIcNLmvXaBD7lKUwKcnGgVziH/CrndX6SldKQNQ==",
       "cpu": [
         "arm64"
       ],
@@ -3591,9 +3445,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.3.72",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.72.tgz",
-      "integrity": "sha512-F3TK8JHP3SRFjLRlzcRVZPnvvGm2CQ5/cwbIkaEq0Dla3kyctU8SiRqvtYwWCW4JuY10cUygIg93Ec/C9Lkk4g==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.5.3.tgz",
+      "integrity": "sha512-zV5utPYBUzYhBOomCByAjKAvfVBcOCJtnszx7Zlfz7SAv/cGm8D1QzPDCvv6jDhIlUtLj6KyL8JXeFr+f95Fjw==",
       "cpu": [
         "ia32"
       ],
@@ -3607,9 +3461,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.3.72",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.72.tgz",
-      "integrity": "sha512-FXMnIUtLl0yEmGkw+xbUg/uUPExvUxUlLSHbX7CnbSuOIHqMHzvEd9skIueLAst4bvmJ8kT1hDyAIWQcTIAJYQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.5.3.tgz",
+      "integrity": "sha512-QmUiXiPIV5gBADfDh8e2jKynEhyRC+dcKP/zF9y5KqDUErYzlhocLd68uYS4uIegP6AylYlmigHgcaktGEE9VQ==",
       "cpu": [
         "x64"
       ],
@@ -3622,13 +3476,28 @@
         "node": ">=10"
       }
     },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true
+    },
     "node_modules/@swc/helpers": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
-      "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.11.tgz",
+      "integrity": "sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.6.tgz",
+      "integrity": "sha512-/JLo/l2JsT/LRd80C3HfbmVpxOAJ11FO2RCEslFrgzLltoP9j8XIbsyDcfCt2WWyX+CM96rBoNM+IToAkFOugg==",
+      "dev": true,
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@szmarczak/http-timer": {
@@ -3727,9 +3596,9 @@
       "dev": true
     },
     "node_modules/@types/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -3769,33 +3638,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -3939,33 +3781,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -4000,33 +3815,6 @@
         "eslint": "^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.2.1.tgz",
@@ -4044,17 +3832,11 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
-      "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -4096,67 +3878,58 @@
       }
     },
     "node_modules/addons-linter": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/addons-linter/-/addons-linter-5.32.0.tgz",
-      "integrity": "sha512-Lf6oOyw8X9z5BMd9xhQwSbPlN2PUlzDLnYLAVT5lkrgXEx0fO9hRk4JRxWZ8+rFGz+mCIA2TTClZF2f+MKgJQA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/addons-linter/-/addons-linter-6.21.0.tgz",
+      "integrity": "sha512-4GBn14BR16FZE7dog6uz+1HO6V3B+mAVxmbwxRhed2y5eyrwIW832TmEpku+5A5bbovBZ4gilXEtBsl6A1AMmg==",
       "dev": true,
       "dependencies": {
         "@fluent/syntax": "0.19.0",
-        "@mdn/browser-compat-data": "5.2.42",
+        "@mdn/browser-compat-data": "5.5.7",
         "addons-moz-compare": "1.3.0",
-        "addons-scanner-utils": "8.5.0",
+        "addons-scanner-utils": "9.9.0",
         "ajv": "8.12.0",
         "chalk": "4.1.2",
         "cheerio": "1.0.0-rc.12",
         "columnify": "1.6.0",
         "common-tags": "1.8.2",
         "deepmerge": "4.3.1",
-        "eslint": "8.36.0",
+        "eslint": "8.56.0",
         "eslint-plugin-no-unsanitized": "4.0.2",
-        "eslint-visitor-keys": "3.3.0",
-        "espree": "9.5.0",
+        "eslint-visitor-keys": "3.4.3",
+        "espree": "9.6.1",
         "esprima": "4.0.1",
         "fast-json-patch": "3.1.1",
-        "glob": "9.3.0",
-        "image-size": "1.0.2",
+        "glob": "10.3.10",
+        "image-size": "1.1.1",
         "is-mergeable-object": "1.1.1",
         "jed": "1.1.1",
         "json-merge-patch": "1.0.2",
         "os-locale": "5.0.0",
-        "pino": "8.11.0",
-        "postcss": "8.4.21",
+        "pino": "8.17.2",
+        "postcss": "8.4.33",
         "relaxed-json": "1.0.3",
-        "semver": "7.3.8",
+        "semver": "7.5.4",
         "sha.js": "2.4.11",
         "source-map-support": "0.5.21",
         "tosource": "1.0.0",
         "upath": "2.0.1",
-        "yargs": "17.7.1",
+        "yargs": "17.7.2",
         "yauzl": "2.10.0"
       },
       "bin": {
         "addons-linter": "bin/addons-linter"
       },
       "engines": {
-        "node": ">=12.21.0"
-      }
-    },
-    "node_modules/addons-linter/node_modules/@eslint/js": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
-      "integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/addons-linter/node_modules/addons-scanner-utils": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/addons-scanner-utils/-/addons-scanner-utils-8.5.0.tgz",
-      "integrity": "sha512-X35SYZRdSnxx7UZuAk+DizKihQp2Ze2c5GV+5nnRr/FFyx/fOgE3Zo8jdhzSne57PENE9w1ZVocBLJTN6UDB3g==",
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/addons-scanner-utils/-/addons-scanner-utils-9.9.0.tgz",
+      "integrity": "sha512-YDP10U3sEZMuIgnjXMiAYgUU64jTbxmhpUXMlhi1nKO4Etz+ctGWoTUst7IQRoLWaY9y2r1KZDG3jALxLA1n7Q==",
       "dev": true,
       "dependencies": {
-        "@types/yauzl": "2.10.0",
+        "@types/yauzl": "2.10.3",
         "common-tags": "1.8.2",
         "first-chunk-stream": "3.0.0",
         "strip-bom-stream": "4.0.0",
@@ -4166,7 +3939,7 @@
       "peerDependencies": {
         "body-parser": "1.20.2",
         "express": "4.18.2",
-        "node-fetch": "2.6.7",
+        "node-fetch": "2.6.11",
         "safe-compare": "1.1.4"
       },
       "peerDependenciesMeta": {
@@ -4184,89 +3957,16 @@
         }
       }
     },
-    "node_modules/addons-linter/node_modules/eslint": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
-      "integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
-      "dev": true,
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.0.1",
-        "@eslint/js": "8.36.0",
-        "@humanwhocodes/config-array": "^0.11.8",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.10.0",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
-        "debug": "^4.3.2",
-        "doctrine": "^3.0.0",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.1",
-        "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.5.0",
-        "esquery": "^1.4.2",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "globals": "^13.19.0",
-        "grapheme-splitter": "^1.0.4",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "is-path-inside": "^3.0.3",
-        "js-sdsl": "^4.1.4",
-        "js-yaml": "^4.1.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.1",
-        "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
-        "text-table": "^0.2.0"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/addons-linter/node_modules/eslint/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/addons-linter/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+    "node_modules/addons-linter/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "node_modules/addons-linter/node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
       "dev": true,
       "optional": true,
       "peer": true,
@@ -4285,40 +3985,36 @@
         }
       }
     },
-    "node_modules/addons-linter/node_modules/postcss": {
-      "version": "8.4.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+    "node_modules/addons-linter/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        }
-      ],
       "dependencies": {
-        "nanoid": "^3.3.4",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/addons-linter/node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/addons-linter/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/addons-moz-compare": {
@@ -5349,21 +5045,29 @@
       "dev": true
     },
     "node_modules/cosmiconfig": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
-      "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "dependencies": {
-        "import-fresh": "^3.2.1",
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0"
+        "parse-json": "^5.2.0"
       },
       "engines": {
         "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/cosmiconfig/node_modules/lines-and-columns": {
@@ -5388,15 +5092,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/cross-spawn": {
@@ -6090,6 +5785,15 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -6241,18 +5945,19 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.46.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.46.0.tgz",
-      "integrity": "sha512-cIO74PvbW0qU8e0mIvk5IV3ToWdCq5FYG6gWPHHkx6gNdjlbAYvtfHmlCMXxjcoVaIdwy/IAt3+mDkZkfvb2Dg==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+      "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.1",
-        "@eslint/js": "^8.46.0",
-        "@humanwhocodes/config-array": "^0.11.10",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.56.0",
+        "@humanwhocodes/config-array": "^0.11.13",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -6260,7 +5965,7 @@
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.2.2",
-        "eslint-visitor-keys": "^3.4.2",
+        "eslint-visitor-keys": "^3.4.3",
         "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
@@ -6666,12 +6371,15 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/ajv": {
@@ -6690,19 +6398,13 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
-      "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
-    "node_modules/eslint/node_modules/espree": {
+    "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
@@ -6711,29 +6413,6 @@
         "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.4.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
-    },
-    "node_modules/espree": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
-      "integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.8.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6906,9 +6585,9 @@
       "dev": true
     },
     "node_modules/fast-redact": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.3.0.tgz",
-      "integrity": "sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -7072,6 +6751,34 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -7177,9 +6884,9 @@
       }
     },
     "node_modules/fx-runner": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fx-runner/-/fx-runner-1.3.0.tgz",
-      "integrity": "sha512-5b37H4GCyhF+Nf8xk9mylXoDq4wb7pbGAXxlCXp/631UTeeZomWSYcEGXumY4wk8g2QAqjPMGdWW+RbNt8PUcA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/fx-runner/-/fx-runner-1.4.0.tgz",
+      "integrity": "sha512-rci1g6U0rdTg6bAaBboP7XdRu01dzTAaKXxFf+PUqGuCv6Xu7o8NZdY1D5MvKGIjb6EdS1g3VlXOgksir1uGkg==",
       "dev": true,
       "dependencies": {
         "commander": "2.9.0",
@@ -7319,15 +7026,19 @@
       }
     },
     "node_modules/glob": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.0.tgz",
-      "integrity": "sha512-EAZejC7JvnQINayvB/7BJbpZpNOJ8Lrw2OZNEvQxe0vaLn1SuwMcfV7/MNaX8L/T0wmptBFI4YMtDvSBxYDc7w==",
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
       "dev": true,
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "minimatch": "^7.4.1",
-        "minipass": "^4.2.4",
-        "path-scurry": "^1.6.1"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -7364,15 +7075,15 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -7501,12 +7212,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
-      "dev": true
-    },
-    "node_modules/grapheme-splitter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
     "node_modules/graphemer": {
@@ -7666,21 +7371,21 @@
       "dev": true
     },
     "node_modules/htmlnano": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.0.4.tgz",
-      "integrity": "sha512-WGCkyGFwjKW1GeCBsPYacMvaMnZtFJ0zIRnC2NCddkA+IOEhTqskXrS7lep+3yYZw/nQ3dW1UAX4yA/GJyR8BA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.1.1.tgz",
+      "integrity": "sha512-kAERyg/LuNZYmdqgCdYvugyLWNFAm8MWXpQMz1pLpetmCbFwoMxvkSoaAMlFrOC4OKTWI4KlZGT/RsNxg4ghOw==",
       "dev": true,
       "dependencies": {
-        "cosmiconfig": "^8.0.0",
+        "cosmiconfig": "^9.0.0",
         "posthtml": "^0.16.5",
         "timsort": "^0.3.0"
       },
       "peerDependencies": {
-        "cssnano": "^6.0.0",
+        "cssnano": "^7.0.0",
         "postcss": "^8.3.11",
-        "purgecss": "^5.0.0",
+        "purgecss": "^6.0.0",
         "relateurl": "^0.2.7",
-        "srcset": "4.0.0",
+        "srcset": "5.0.1",
         "svgo": "^3.0.2",
         "terser": "^5.10.0",
         "uncss": "^0.17.3"
@@ -7804,9 +7509,9 @@
       }
     },
     "node_modules/image-size": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz",
-      "integrity": "sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.1.1.tgz",
+      "integrity": "sha512-541xKlUw6jr/6gGuk92F+mYM5zaFAc5ahphvkqvNe2bQ6gVBkd6bfrmVJ2t4KDAfikAYZyIqTnktX3i6/aQDrQ==",
       "dev": true,
       "dependencies": {
         "queue": "6.0.2"
@@ -7815,7 +7520,7 @@
         "image-size": "bin/image-size.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.x"
       }
     },
     "node_modules/immediate": {
@@ -8349,6 +8054,24 @@
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "dev": true
     },
+    "node_modules/jackspeak": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/jed": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/jed/-/jed-1.1.1.tgz",
@@ -8362,16 +8085,6 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/js-sdsl": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.2.tgz",
-      "integrity": "sha512-dwXFwByc/ajSV6m5bcKAPwe4yDDF6D614pxmIi5odytzxRlwqF6nwoiCek80Ixc7Cvma5awClxrzFtxCQvcM8w==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/js-tokens": {
@@ -8677,9 +8390,9 @@
       "dev": true
     },
     "node_modules/lightningcss": {
-      "version": "1.21.5",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.21.5.tgz",
-      "integrity": "sha512-/pEUPeih2EwIx9n4T82aOG6CInN83tl/mWlw6B5gWLf36UplQi1L+5p3FUHsdt4fXVfOkkh9KIaM3owoq7ss8A==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.24.1.tgz",
+      "integrity": "sha512-kUpHOLiH5GB0ERSv4pxqlL0RYKnOXtgGtVe7shDGfhS0AZ4D1ouKFYAcLcZhql8aMspDNzaUCumGHZ78tb2fTg==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
@@ -8692,20 +8405,21 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.21.5",
-        "lightningcss-darwin-x64": "1.21.5",
-        "lightningcss-linux-arm-gnueabihf": "1.21.5",
-        "lightningcss-linux-arm64-gnu": "1.21.5",
-        "lightningcss-linux-arm64-musl": "1.21.5",
-        "lightningcss-linux-x64-gnu": "1.21.5",
-        "lightningcss-linux-x64-musl": "1.21.5",
-        "lightningcss-win32-x64-msvc": "1.21.5"
+        "lightningcss-darwin-arm64": "1.24.1",
+        "lightningcss-darwin-x64": "1.24.1",
+        "lightningcss-freebsd-x64": "1.24.1",
+        "lightningcss-linux-arm-gnueabihf": "1.24.1",
+        "lightningcss-linux-arm64-gnu": "1.24.1",
+        "lightningcss-linux-arm64-musl": "1.24.1",
+        "lightningcss-linux-x64-gnu": "1.24.1",
+        "lightningcss-linux-x64-musl": "1.24.1",
+        "lightningcss-win32-x64-msvc": "1.24.1"
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.21.5",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.21.5.tgz",
-      "integrity": "sha512-z05hyLX85WY0UfhkFUOrWEFqD69lpVAmgl3aDzMKlIZJGygbhbegqb4PV8qfUrKKNBauut/qVNPKZglhTaDDxA==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.24.1.tgz",
+      "integrity": "sha512-1jQ12jBy+AE/73uGQWGSafK5GoWgmSiIQOGhSEXiFJSZxzV+OXIx+a9h2EYHxdJfX864M+2TAxWPWb0Vv+8y4w==",
       "cpu": [
         "arm64"
       ],
@@ -8723,9 +8437,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.21.5",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.21.5.tgz",
-      "integrity": "sha512-MSJhmej/U9MrdPxDk7+FWhO8+UqVoZUHG4VvKT5RQ4RJtqtANTiWiI97LvoVNMtdMnHaKs1Pkji6wHUFxjJsHQ==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.24.1.tgz",
+      "integrity": "sha512-R4R1d7VVdq2mG4igMU+Di8GPf0b64ZLnYVkubYnGG0Qxq1KaXQtAzcLI43EkpnoWvB/kUg8JKCWH4S13NfiLcQ==",
       "cpu": [
         "x64"
       ],
@@ -8742,10 +8456,30 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.24.1.tgz",
+      "integrity": "sha512-z6NberUUw5ALES6Ixn2shmjRRrM1cmEn1ZQPiM5IrZ6xHHL5a1lPin9pRv+w6eWfcrEo+qGG6R9XfJrpuY3e4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.21.5",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.21.5.tgz",
-      "integrity": "sha512-xN6+5/JsMrbZHL1lPl+MiNJ3Xza12ueBKPepiyDCFQzlhFRTj7D0LG+cfNTzPBTO8KcYQynLpl1iBB8LGp3Xtw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.24.1.tgz",
+      "integrity": "sha512-NLQLnBQW/0sSg74qLNI8F8QKQXkNg4/ukSTa+XhtkO7v3BnK19TS1MfCbDHt+TTdSgNEBv0tubRuapcKho2EWw==",
       "cpu": [
         "arm"
       ],
@@ -8763,9 +8497,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.21.5",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.21.5.tgz",
-      "integrity": "sha512-KfzFNhC4XTbmG3ma/xcTs/IhCwieW89XALIusKmnV0N618ZDXEB0XjWOYQRCXeK9mfqPdbTBpurEHV/XZtkniQ==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.24.1.tgz",
+      "integrity": "sha512-AQxWU8c9E9JAjAi4Qw9CvX2tDIPjgzCTrZCSXKELfs4mCwzxRkHh2RCxX8sFK19RyJoJAjA/Kw8+LMNRHS5qEg==",
       "cpu": [
         "arm64"
       ],
@@ -8783,9 +8517,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.21.5",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.21.5.tgz",
-      "integrity": "sha512-bc0GytQO5Mn9QM6szaZ+31fQHNdidgpM1sSCwzPItz8hg3wOvKl8039rU0veMJV3ZgC9z0ypNRceLrSHeRHmXw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.24.1.tgz",
+      "integrity": "sha512-JCgH/SrNrhqsguUA0uJUM1PvN5+dVuzPIlXcoWDHSv2OU/BWlj2dUYr3XNzEw748SmNZPfl2NjQrAdzaPOn1lA==",
       "cpu": [
         "arm64"
       ],
@@ -8803,9 +8537,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.21.5",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.21.5.tgz",
-      "integrity": "sha512-JwMbgypPQgc2kW2av3OwzZ8cbrEuIiDiXPJdXRE6aVxu67yHauJawQLqJKTGUhiAhy6iLDG8Wg0a3/ziL+m+Kw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.24.1.tgz",
+      "integrity": "sha512-TYdEsC63bHV0h47aNRGN3RiK7aIeco3/keN4NkoSQ5T8xk09KHuBdySltWAvKLgT8JvR+ayzq8ZHnL1wKWY0rw==",
       "cpu": [
         "x64"
       ],
@@ -8823,9 +8557,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.21.5",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.21.5.tgz",
-      "integrity": "sha512-Ib8b6IQ/OR/VrPU6YBgy4T3QnuHY7DUa95O+nz+cwrTkMSN6fuHcTcIaz4t8TJ6HI5pl3uxUOZjmtls2pyQWow==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.24.1.tgz",
+      "integrity": "sha512-HLfzVik3RToot6pQ2Rgc3JhfZkGi01hFetHt40HrUMoeKitLoqUUT5owM6yTZPTytTUW9ukLBJ1pc3XNMSvlLw==",
       "cpu": [
         "x64"
       ],
@@ -8843,9 +8577,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.21.5",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.21.5.tgz",
-      "integrity": "sha512-A8cSi8lUpBeVmoF+DqqW7cd0FemDbCuKr490IXdjyeI+KL8adpSKUs8tcqO0OXPh1EoDqK7JNkD/dELmd4Iz5g==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.24.1.tgz",
+      "integrity": "sha512-joEupPjYJ7PjZtDsS5lzALtlAudAbgIBMGJPNeFe5HfdmJXFd13ECmEM+5rXNxYVMRHua2w8132R6ab5Z6K9Ow==",
       "cpu": [
         "x64"
       ],
@@ -8872,43 +8606,34 @@
       }
     },
     "node_modules/lmdb": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.7.11.tgz",
-      "integrity": "sha512-x9bD4hVp7PFLUoELL8RglbNXhAMt5CYhkmss+CEau9KlNoilsTzNi9QDsPZb3KMpOGZXG6jmXhW3bBxE2XVztw==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.8.5.tgz",
+      "integrity": "sha512-9bMdFfc80S+vSldBmG3HOuLVHnxRdNTlpzR6QDnzqCQtCzGUEAGTzBKYMeIM+I/sU4oZfgbcbS7X7F65/z/oxQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "msgpackr": "1.8.5",
-        "node-addon-api": "^4.3.0",
-        "node-gyp-build-optional-packages": "5.0.6",
-        "ordered-binary": "^1.4.0",
+        "msgpackr": "^1.9.5",
+        "node-addon-api": "^6.1.0",
+        "node-gyp-build-optional-packages": "5.1.1",
+        "ordered-binary": "^1.4.1",
         "weak-lru-cache": "^1.2.2"
       },
       "bin": {
         "download-lmdb-prebuilds": "bin/download-prebuilds.js"
       },
       "optionalDependencies": {
-        "@lmdb/lmdb-darwin-arm64": "2.7.11",
-        "@lmdb/lmdb-darwin-x64": "2.7.11",
-        "@lmdb/lmdb-linux-arm": "2.7.11",
-        "@lmdb/lmdb-linux-arm64": "2.7.11",
-        "@lmdb/lmdb-linux-x64": "2.7.11",
-        "@lmdb/lmdb-win32-x64": "2.7.11"
-      }
-    },
-    "node_modules/lmdb/node_modules/msgpackr": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.5.tgz",
-      "integrity": "sha512-mpPs3qqTug6ahbblkThoUY2DQdNXcm4IapwOS3Vm/87vmpzLVelvp9h3It1y9l1VPpiFLV11vfOXnmeEwiIXwg==",
-      "dev": true,
-      "optionalDependencies": {
-        "msgpackr-extract": "^3.0.1"
+        "@lmdb/lmdb-darwin-arm64": "2.8.5",
+        "@lmdb/lmdb-darwin-x64": "2.8.5",
+        "@lmdb/lmdb-linux-arm": "2.8.5",
+        "@lmdb/lmdb-linux-arm64": "2.8.5",
+        "@lmdb/lmdb-linux-x64": "2.8.5",
+        "@lmdb/lmdb-win32-x64": "2.8.5"
       }
     },
     "node_modules/lmdb/node_modules/node-addon-api": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
       "dev": true
     },
     "node_modules/load-json-file": {
@@ -9006,9 +8731,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
-      "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
@@ -9161,12 +8886,12 @@
       }
     },
     "node_modules/minipass": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mkdirp": {
@@ -9198,9 +8923,9 @@
       "dev": true
     },
     "node_modules/msgpackr": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.9.5.tgz",
-      "integrity": "sha512-/IJ3cFSN6Ci3eG2wLhbFEL6GT63yEaoN/R5My2QkV6zro+OJaVRLPlwvxY7EtHYSmDlQpk8stvOQTL2qJFkDRg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.1.tgz",
+      "integrity": "sha512-r5VRLv9qouXuLiIBrLpl2d5ZvPt8svdQTl5/vMvE4nzDMyEX4sgW5yWhuBBj5UmgwOTWj8CIdSXn5sAfsHAWIQ==",
       "dev": true,
       "optionalDependencies": {
         "msgpackr-extract": "^3.0.2"
@@ -9345,9 +9070,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "dev": true,
       "funding": [
         {
@@ -9391,10 +9116,13 @@
       "dev": true
     },
     "node_modules/node-addon-api": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz",
-      "integrity": "sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA==",
-      "dev": true
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
+      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
+      "dev": true,
+      "engines": {
+        "node": "^16 || ^18 || >= 20"
+      }
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -9443,14 +9171,26 @@
       }
     },
     "node_modules/node-gyp-build-optional-packages": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.6.tgz",
-      "integrity": "sha512-2ZJErHG4du9G3/8IWl/l9Bp5BBFy63rno5GVmjQijvTuUZKsl6g8RB4KH/x3NLcV5ZBb4GsXmAuTYr6dRml3Gw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz",
+      "integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
       "dev": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
       "bin": {
         "node-gyp-build-optional-packages": "bin.js",
         "node-gyp-build-optional-packages-optional": "optional.js",
         "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages/node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/node-notifier": {
@@ -9827,10 +9567,13 @@
       }
     },
     "node_modules/on-exit-leak-free": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
-      "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w==",
-      "dev": true
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -9891,9 +9634,9 @@
       }
     },
     "node_modules/ordered-binary": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.4.1.tgz",
-      "integrity": "sha512-9LtiGlPy982CsgxZvJGNNp2/NnrgEr6EAyN3iIEP3/8vd3YLgAZQHbQ75ZrkfBRGrNg37Dk3U6tuVb+B4Xfslg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.5.1.tgz",
+      "integrity": "sha512-5VyHfHY3cd0iza71JepYG50My+YUbrFtGoUz2ooEydPyPM7Aai/JW098juLr+RG6+rDJuzNNTsEQu2DZa1A41A==",
       "dev": true
     },
     "node_modules/os-locale": {
@@ -10004,22 +9747,22 @@
       "dev": true
     },
     "node_modules/parcel": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.9.3.tgz",
-      "integrity": "sha512-2GTVocFkwblV/TIg9AmT7TI2fO4xdWkyN8aFUEVtiVNWt96GTR3FgQyHFValfCbcj1k9Xf962Ws2hYXYUr9k1Q==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.12.0.tgz",
+      "integrity": "sha512-W+gxAq7aQ9dJIg/XLKGcRT0cvnStFAQHPaI0pvD0U2l6IVLueUAm3nwN7lkY62zZNmlvNx6jNtE4wlbS+CyqSg==",
       "dev": true,
       "dependencies": {
-        "@parcel/config-default": "2.9.3",
-        "@parcel/core": "2.9.3",
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/events": "2.9.3",
-        "@parcel/fs": "2.9.3",
-        "@parcel/logger": "2.9.3",
-        "@parcel/package-manager": "2.9.3",
-        "@parcel/reporter-cli": "2.9.3",
-        "@parcel/reporter-dev-server": "2.9.3",
-        "@parcel/reporter-tracer": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/config-default": "2.12.0",
+        "@parcel/core": "2.12.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/events": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/package-manager": "2.12.0",
+        "@parcel/reporter-cli": "2.12.0",
+        "@parcel/reporter-dev-server": "2.12.0",
+        "@parcel/reporter-tracer": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "chalk": "^4.1.0",
         "commander": "^7.0.0",
         "get-port": "^4.2.0"
@@ -10133,12 +9876,12 @@
       "dev": true
     },
     "node_modules/path-scurry": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
-      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.2.tgz",
+      "integrity": "sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==",
       "dev": true,
       "dependencies": {
-        "lru-cache": "^9.1.1 || ^10.0.0",
+        "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
@@ -10146,15 +9889,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/minipass": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.2.tgz",
-      "integrity": "sha512-eL79dXrE1q9dBbDCLg7xfn/vl7MS4F1gvJAgjJrQli/jbQWdUttuVawphqpffoIYfRdq78LHx6GP4bU/EQ2ATA==",
-      "dev": true,
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/path-type": {
@@ -10221,21 +9955,21 @@
       }
     },
     "node_modules/pino": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.11.0.tgz",
-      "integrity": "sha512-Z2eKSvlrl2rH8p5eveNUnTdd4AjJk8tAsLkHYZQKGHP4WTh2Gi1cOSOs3eWPqaj+niS3gj4UkoreoaWgF3ZWYg==",
+      "version": "8.17.2",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.17.2.tgz",
+      "integrity": "sha512-LA6qKgeDMLr2ux2y/YiUt47EfgQ+S9LznBWOJdN3q1dx2sv0ziDLUBeVpyVv17TEcGCBuWf0zNtg3M5m1NhhWQ==",
       "dev": true,
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "v1.0.0",
+        "pino-abstract-transport": "v1.1.0",
         "pino-std-serializers": "^6.0.0",
-        "process-warning": "^2.0.0",
+        "process-warning": "^3.0.0",
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
-        "sonic-boom": "^3.1.0",
+        "sonic-boom": "^3.7.0",
         "thread-stream": "^2.0.0"
       },
       "bin": {
@@ -10243,9 +9977,9 @@
       }
     },
     "node_modules/pino-abstract-transport": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
-      "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz",
+      "integrity": "sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==",
       "dev": true,
       "dependencies": {
         "readable-stream": "^4.0.0",
@@ -10259,9 +9993,9 @@
       "dev": true
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.4.33",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
+      "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
       "dev": true,
       "funding": [
         {
@@ -10277,10 +10011,8 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -10549,9 +10281,9 @@
       "dev": true
     },
     "node_modules/process-warning": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
-      "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
       "dev": true
     },
     "node_modules/progress": {
@@ -10778,9 +10510,9 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
-      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
       "dev": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -11325,9 +11057,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -11487,9 +11219,9 @@
       }
     },
     "node_modules/sonic-boom": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.3.0.tgz",
-      "integrity": "sha512-LYxp34KlZ1a2Jb8ZQgFCK3niIHzibdwtwNUWKg0qQRzsDoJ3Gfgkf8KdBTFU3SkejDEIlWwnSnpVdOZIhFMl/g==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
+      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
       "dev": true,
       "dependencies": {
         "atomic-sleep": "^1.0.0"
@@ -11595,12 +11327,14 @@
       "peer": true
     },
     "node_modules/srcset": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/srcset/-/srcset-4.0.0.tgz",
-      "integrity": "sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/srcset/-/srcset-5.0.1.tgz",
+      "integrity": "sha512-/P1UYbGfJVlxZag7aABNRrulEXAwCSDo7fklafOQrantuPTDmYgijJMks2zusPCVzgW9+4P69mq7w6pYuZpgxw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -11686,6 +11420,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "6.0.1",
@@ -11807,6 +11562,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-5.0.0.tgz",
@@ -11896,9 +11664,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
-      "integrity": "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.2.0.tgz",
+      "integrity": "sha512-4PP6CMW/V7l/GmKRKzsLR8xxjdHTV4IMvhTnpuHwwBazSIlw5W/5SmPjN8Dwyt7lKbSJrRDgp4t9ph0HgChFBQ==",
       "dev": true,
       "optional": true,
       "peer": true,
@@ -11906,7 +11674,8 @@
         "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
         "css-select": "^5.1.0",
-        "css-tree": "^2.2.1",
+        "css-tree": "^2.3.1",
+        "css-what": "^6.1.0",
         "csso": "^5.0.5",
         "picocolors": "^1.0.0"
       },
@@ -12036,9 +11805,9 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.3.0.tgz",
-      "integrity": "sha512-kaDqm1DET9pp3NXwR8382WHbnpXnRkN9xGN9dQt3B2+dmXiW8X1SOwmFOxAErEQ47ObhZ96J6yhZNXuyCOL7KA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
       "dev": true,
       "dependencies": {
         "real-require": "^0.2.0"
@@ -12464,9 +12233,9 @@
       "dev": true
     },
     "node_modules/utility-types": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
-      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -12552,14 +12321,14 @@
       "dev": true
     },
     "node_modules/web-ext": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/web-ext/-/web-ext-7.6.2.tgz",
-      "integrity": "sha512-xlxbzgFBIS/UWWlvWxyR1PIqRRzDj1cutoHh+VZu4ZTcJTfv35KVdKkLRZv4PQwHu4dg8VfTg7WEcNP4QLaaFQ==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/web-ext/-/web-ext-7.11.0.tgz",
+      "integrity": "sha512-EG6YXHITNDJB/h6Rc5FF08eMoN45sZPBBIIlEraBzxJ0RdJZ8Z3xvUUawbDwt+mowfv9X0XRWlLSwdWbRKgojg==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "7.21.0",
         "@devicefarmer/adbkit": "3.2.3",
-        "addons-linter": "5.32.0",
+        "addons-linter": "6.21.0",
         "bunyan": "1.8.15",
         "camelcase": "7.0.1",
         "chrome-launcher": "0.15.1",
@@ -12568,7 +12337,7 @@
         "es6-error": "4.1.1",
         "firefox-profile": "4.3.2",
         "fs-extra": "11.1.0",
-        "fx-runner": "1.3.0",
+        "fx-runner": "1.4.0",
         "import-fresh": "3.3.0",
         "jose": "4.13.1",
         "mkdirp": "1.0.4",
@@ -12727,6 +12496,44 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
@@ -12838,12 +12645,6 @@
       "engines": {
         "node": ">=4.0"
       }
-    },
-    "node_modules/xxhash-wasm": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-0.4.2.tgz",
-      "integrity": "sha512-/eyHVRJQCirEkSZ1agRSCwriMhwlyUcFkXD5TPVSLP+IPzjsqMVzZwdoczLp1SoQU0R3dxz1RpIK+4YNQbCVOA==",
-      "dev": true
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "prettier": "^3.0.0",
     "typescript": "^5.1.6",
     "watcher": "^2.2.2",
-    "web-ext": "^7.6.2",
+    "web-ext": "^7.11.0",
     "web-ext-types": "^3.2.1"
   },
   "dependencies": {


### PR DESCRIPTION
This fixes the majority of the issues under `npm audit`, except a few moderate issues that due to the `sign-addon` package. This package has been deprecated and will eventually be removed as a dependency of the `web-ext` package.