### PR TITLE
Modify build process to fix blank page issue

### DIFF
--- a/bin/clean.mjs
+++ b/bin/clean.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from "node:url";
 
 const DIRNAME = path.dirname(fileURLToPath(import.meta.url));
 
-const DIRS = [".prettier-cache", "dist", "web-ext-artifacts"];
+const DIRS = [".parcel-cache", ".prettier-cache", "dist", "web-ext-artifacts"];
 
 for (const dir of DIRS) {
   const dirPath = path.join(DIRNAME, "..", dir);


### PR DESCRIPTION
Fixed an issue of the extension showing a blank page sometimes by changing clean.mjs to rewrite to the files in .parcel-cache with every build.