### PR TITLE
Live / Preview Experiment Browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MPL-2.0",
       "dependencies": {
+        "@mozilla/nimbus-schemas": "^2024.3.1",
         "mozjexl": "github:mozilla/mozjexl",
         "normalize.css": "^8.0.1",
         "react": "^18.3.1",
@@ -1347,6 +1348,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@mozilla/nimbus-schemas": {
+      "version": "2024.3.1",
+      "resolved": "https://registry.npmjs.org/@mozilla/nimbus-schemas/-/nimbus-schemas-2024.3.1.tgz",
+      "integrity": "sha512-wlqaJiHl95rvEF7FmR7EnhiaJhHX5LizHMdiOcsJ4bmTfRF+rtOn3P0/XlLn7Eepr0lAdnh//QVwyTPbvXkhhw=="
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "web-ext-types": "^3.2.1"
   },
   "dependencies": {
+    "@mozilla/nimbus-schemas": "^2024.3.1",
     "mozjexl": "github:mozilla/mozjexl",
     "normalize.css": "^8.0.1",
     "react": "^18.3.1",

--- a/src/ui/components/ExperimentBrowserPage.tsx
+++ b/src/ui/components/ExperimentBrowserPage.tsx
@@ -1,0 +1,111 @@
+import { FC, useCallback, useEffect, useState } from "react";
+import { NimbusExperiment } from "@mozilla/nimbus-schemas";
+
+const PROD_URL =
+  "https://experimenter.services.mozilla.com/api/v6/experiments/";
+const STAGE_URL =
+  "https://stage.experimenter.nonprod.dataops.mozgcp.net/api/v6/experiments/";
+
+type Status = "Live" | "Preview";
+
+enum Environment {
+  PROD = "prod",
+  STAGE = "stage",
+}
+
+const ExperimentBrowserPage: FC = () => {
+  const [environment, setEnvironment] = useState<Environment>(Environment.PROD);
+  const [status, setStatus] = useState<Status>("Live");
+  const [experiments, setExperiments] = useState<NimbusExperiment[]>([]);
+
+  const fetchExperiments = useCallback(
+    async (forceRefresh = false) => {
+      let url = environment === Environment.PROD ? PROD_URL : STAGE_URL;
+      url += `?status=${status}`;
+      if (forceRefresh) {
+        url += `&bust-cache=${Date.now()}`;
+      }
+
+      try {
+        const fetchedExperiments = await fetch(url).then(
+          (rsp) => rsp.json() as Promise<NimbusExperiment[]>,
+        );
+        setExperiments(fetchedExperiments);
+      } catch (error) {
+        console.error("Error fetching experiments:", error);
+      }
+    },
+    [environment, status],
+  );
+
+  useEffect(() => {
+    void fetchExperiments();
+  }, [fetchExperiments]);
+
+  return (
+    <div className="experiment-viewer">
+      <h1 className="experiment-viewer__title">{status} Experiments</h1>
+      <div className="experiment-viewer__controls">
+        <label className="experiment-viewer-controls__title">
+          Environment:
+          <select
+            className="experiment-viewer-controls__dropdown"
+            value={environment}
+            onChange={(e) => setEnvironment(e.target.value as Environment)}
+          >
+            <option value="prod">Prod</option>
+            <option value="stage">Stage</option>
+          </select>
+        </label>
+        <label className="experiment-viewer-controls__title">
+          Status:
+          <select
+            className="experiment-viewer-controls__dropdown"
+            value={status}
+            onChange={(e) => setStatus(e.target.value as Status)}
+          >
+            <option value="Live">Live</option>
+            <option value="Preview">Preview</option>
+          </select>
+        </label>
+        <button
+          className="experiment-viewer-controls__button"
+          onClick={() => fetchExperiments(true)}
+        >
+          Refresh
+        </button>
+      </div>
+      <div className="experiment-viewer__list">
+        <table>
+          <thead>
+            <tr>
+              <th>Experiment</th>
+              <th>Channel</th>
+              <th>Version</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {experiments.map((experiment) => (
+              <tr key={experiment.id}>
+                <td>
+                  {experiment.userFacingName}:{" "}
+                  {experiment.userFacingDescription}
+                </td>
+                <td>{experiment.channel}</td>
+                <td>{experiment.schemaVersion}</td>
+                <td>
+                  {experiment.isEnrollmentPaused
+                    ? "Enrolling"
+                    : "Enrollment Paused"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default ExperimentBrowserPage;

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -13,6 +13,9 @@ const Sidebar: FC = () => {
       <Link to="/jexl-debugger" className="sidebar__link">
         JEXL Debugger
       </Link>
+      <Link to="/experiment-browser" className="sidebar__link">
+        Experiment Browser
+      </Link>
       <Link to="/settings" className="sidebar__link">
         Settings
       </Link>

--- a/src/ui/index.css
+++ b/src/ui/index.css
@@ -367,3 +367,84 @@ pre {
 .settings__update-button:hover {
     background-color: white;
 }
+
+.experiment-viewer__title {
+    color: #6a3d72;
+    font-size: 1.7rem;
+    font-weight: bold;
+    margin-top: 0px;
+    padding-left: 15px;
+    padding-top: 15px;
+    margin-bottom: 20px;
+}
+
+.experiment-viewer__controls {
+    margin-bottom: 25px;
+    padding-left: 15px;
+    color: #6a3d72;
+}
+
+.experiment-viewer__list {
+    margin: 15px;
+}
+
+.experiment-viewer__list table {
+    width: 100%;
+    border-collapse: collapse;
+
+  }
+
+  .experiment-viewer__list th, .experiment-viewer__list td {
+    border-bottom: 2px solid #f0eaf0;
+    padding-top: 15px;
+    padding-bottom: 15px;
+    padding-right: 20px;
+    text-align: center;
+  }
+  
+  .experiment-viewer__list th {
+    background-color: #f0eaf0;
+    color: #6a3d72;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+  
+  .experiment-viewer__list tr:last-child td {
+    border-bottom: none;
+  }
+
+  .experiment-viewer__list td:first-child {
+    text-align: left;
+  }
+
+  .experiment-viewer-controls__title {
+    margin-right: 20px;
+    font-size: 1.1rem;
+  }
+
+  .experiment-viewer-controls__dropdown {
+    margin-left: 10px;
+    padding: 5px 20px;
+    background-color: white;
+    font-family: monospace;
+    font-size: 1rem;
+    border: 2px solid rgb(212, 208, 208);
+    border-radius: 8px;
+    resize: none;
+    color: #6a3d72;
+  }
+
+  .experiment-viewer-controls__button {
+    margin-left: 40px;
+    padding: 5px 20px;
+    background-color: white;
+    color: #6a3d72;
+    border-radius: 8px;
+    border: 2px solid rgb(212, 208, 208);
+    font-size: 1.1em;
+    box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.2);
+  }
+
+  .experiment-viewer-controls__button:hover {
+    background-color: #f0eaf0;
+}

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -13,6 +13,7 @@ import MainPage from "./components/MainPage";
 import FeatureConfigPage from "./components/FeatureConfigPage";
 import SettingsPage from "./components/SettingsPage";
 import JEXLDebuggerPage from "./components/JEXLDebuggerPage";
+import ExperimentBrowserPage from "./components/ExperimentBrowserPage";
 
 document.addEventListener("DOMContentLoaded", () => {
   document.querySelectorAll("#app").forEach((el) => {
@@ -31,6 +32,10 @@ document.addEventListener("DOMContentLoaded", () => {
                 element={<FeatureConfigPage />}
               />
               <Route path="/jexl-debugger" element={<JEXLDebuggerPage />} />
+              <Route
+                path="/experiment-browser"
+                element={<ExperimentBrowserPage />}
+              />
               <Route path="/settings" element={<SettingsPage />} />
             </Routes>
           </div>


### PR DESCRIPTION
Added functionality to view live and preview experiments on Experimenter Prod and Stage, with cache-busting option for force refresh.

Fixes #19 