### PR TITLE
Allow re-enrollment in recipe

### DIFF
--- a/src/apis/nimbus.json
+++ b/src/apis/nimbus.json
@@ -14,6 +14,11 @@
             "type": "object",
             "additionalProperties": true,
             "description": "An object representing the experiment to enroll in."
+          },
+          {
+            "name": "forceEnroll",
+            "type": "boolean",
+            "description": "A boolean representing whether or not the enrollment should be forced."
           }
         ]
       },

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -57,28 +57,31 @@ declare module "mozjexl/lib/parser/Parser" {
   }
 }
 
-declare namespace browser.experiments.nimbus {
-  type EnrollWithFeatureConfigResult =
-    | {
-        enrolled: true;
-        error: null;
-      }
-    | {
-        enrolled: false;
-        error: {
-          slugExistsInStore: boolean;
-          activeEnrollment: string | null;
-        };
+type EnrollInExperimentResult =
+  | {
+      enrolled: true;
+      error: null;
+    }
+  | {
+      enrolled: false;
+      error: {
+        slugExistsInStore: boolean;
+        activeEnrollment: string | null;
       };
+    };
 
-  function enrollInExperiment(jsonData: object): Promise<boolean>;
+declare namespace browser.experiments.nimbus {
+  function enrollInExperiment(
+    jsonData: object,
+    forceEnroll: boolean,
+  ): Promise<EnrollInExperimentResult>;
 
   function enrollWithFeatureConfig(
     featureId: string,
     featureValue: object,
     isRollout: boolean,
     forceEnroll: boolean,
-  ): Promise<EnrollWithFeatureConfigResult>;
+  ): Promise<EnrollInExperimentResult>;
 
   function getFeatureConfigs(): Promise<string[]>;
 

--- a/src/ui/components/EnrollmentError.tsx
+++ b/src/ui/components/EnrollmentError.tsx
@@ -1,0 +1,57 @@
+import { FC } from "react";
+
+const EnrollmentError: FC<{
+  slug: string;
+  enrollError: EnrollInExperimentResult["error"] | null;
+}> = ({ slug, enrollError }) => {
+  if (!enrollError) {
+    return null;
+  }
+  const { activeEnrollment, slugExistsInStore } = enrollError;
+
+  if (activeEnrollment && slugExistsInStore && slug == activeEnrollment) {
+    return (
+      <p>
+        There is already an enrollment for the slug: <strong>{slug}</strong>.
+        Would you like to proceed with force enrollment by unenrolling,
+        deleting, and enrolling into the new configuration?
+      </p>
+    );
+  } else if (
+    activeEnrollment &&
+    slugExistsInStore &&
+    slug !== activeEnrollment
+  ) {
+    return (
+      <p>
+        There is already an active enrollment for the feature with a different
+        slug. Would you like to proceed with force enrollment by unenrolling,
+        deleting, and enrolling into the new configuration?
+      </p>
+    );
+  }
+
+  if (activeEnrollment) {
+    return (
+      <p>
+        There is an active enrollment for the slug:{" "}
+        <strong>{activeEnrollment}</strong>. Would you like to unenroll from the
+        active enrollment and enroll into the new configuration?
+      </p>
+    );
+  }
+
+  if (slugExistsInStore) {
+    return (
+      <p>
+        There is an inactive enrollment stored for the slug:{" "}
+        <strong>{slug}</strong>. Would you like to delete the inactive
+        enrollment and enroll into the new configuration?
+      </p>
+    );
+  }
+
+  return null;
+};
+
+export default EnrollmentError;

--- a/src/ui/components/RecipeEnrollmentPage.tsx
+++ b/src/ui/components/RecipeEnrollmentPage.tsx
@@ -1,38 +1,79 @@
 import { ChangeEvent, FC, useState, useCallback } from "react";
-import { Form, Container, Button } from "react-bootstrap";
+import { Form, Container, Button, Modal } from "react-bootstrap";
 
 import { useToastsContext } from "../hooks/useToasts";
+import EnrollmentError from "./EnrollmentError";
+
+type EnrollError = EnrollInExperimentResult["error"] & { slug: string };
+type ExperimentWithSlug = { slug?: string };
 
 const RecipeEnrollmentPage: FC = () => {
   const [jsonInput, setJsonInput] = useState("");
+  const [enrollError, setEnrollError] = useState<EnrollError | null>(null);
   const { addToast } = useToastsContext();
 
   const handleInputChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
       setJsonInput(event.target.value);
     },
-    [],
+    [setJsonInput],
   );
 
-  const handleEnrollClick = useCallback(async () => {
-    try {
-      const result = await browser.experiments.nimbus.enrollInExperiment(
-        JSON.parse(jsonInput) as object,
-      );
-
-      if (result) {
-        addToast({ message: "Enrollment successful", variant: "success" });
-        setJsonInput("");
-      } else {
-        addToast({ message: "Enrollment failed", variant: "danger" });
+  const handleEnrollClick = useCallback(
+    async (
+      event?: React.MouseEvent<HTMLButtonElement>,
+      forceEnroll = false,
+    ) => {
+      if (!jsonInput) {
+        addToast({ message: "Invalid Input: Enter JSON", variant: "danger" });
+        return;
       }
-    } catch (error) {
-      addToast({
-        message: `Error enrolling into experiment: ${(error as Error).message ?? String(error)}`,
-        variant: "danger",
-      });
-    }
-  }, [jsonInput, setJsonInput, addToast]);
+
+      let parsedRecipe: ExperimentWithSlug;
+      try {
+        parsedRecipe = JSON.parse(jsonInput) as ExperimentWithSlug;
+      } catch (error) {
+        addToast({
+          message: `Error enrolling into experiment: ${
+            (error as Error).message ?? String(error)
+          }`,
+          variant: "danger",
+        });
+        return;
+      }
+
+      try {
+        const result = await browser.experiments.nimbus.enrollInExperiment(
+          parsedRecipe,
+          forceEnroll,
+        );
+
+        if (result.enrolled) {
+          addToast({ message: "Enrollment successful", variant: "success" });
+          setJsonInput("");
+        } else if (result.error) {
+          setEnrollError({ slug: parsedRecipe.slug ?? "", ...result.error });
+        }
+      } catch (error) {
+        addToast({
+          message: `Error enrolling into experiment: ${
+            (error as Error).message ?? String(error)
+          }`,
+          variant: "danger",
+        });
+      }
+    },
+    [jsonInput, setJsonInput, addToast, setEnrollError],
+  );
+
+  const handleModalConfirm = useCallback(async () => {
+    setEnrollError(null);
+    await handleEnrollClick(undefined, true);
+  }, [handleEnrollClick, setEnrollError]);
+
+  const handleModalClose = useCallback(() => {
+    setEnrollError(null);
+  }, [setEnrollError]);
 
   return (
     <Container className="main-content m-0 p-2">
@@ -53,6 +94,23 @@ const RecipeEnrollmentPage: FC = () => {
           Enroll
         </Button>
       </Form>
+
+      <Modal show={!!enrollError} onHide={handleModalClose}>
+        <Modal.Header closeButton>
+          <Modal.Title>Force Enrollment</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <EnrollmentError slug={enrollError?.slug} enrollError={enrollError} />
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={handleModalClose}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={handleModalConfirm}>
+            Force Enroll
+          </Button>
+        </Modal.Footer>
+      </Modal>
     </Container>
   );
 };


### PR DESCRIPTION
This change checks for existing enrollments, and if present shows the user a modal asking whether they want to force enroll. If so, it unenrolls them from the previous one, and deletes it before proceeding with the new enrollment.

Fixes #50 