### PR TITLE
fix(ui): sanitize JSON input in FeatureConfigPage and RecipeEnrollmen…

### DIFF
--- a/src/ui/components/FeatureConfigPage.tsx
+++ b/src/ui/components/FeatureConfigPage.tsx
@@ -2,6 +2,7 @@ import { ChangeEvent, FC, useState, useCallback, useMemo } from "react";
 import { Form, Container, Button, Row, Col, Modal } from "react-bootstrap";
 
 import { useToastsContext } from "../hooks/useToasts";
+import { sanitizeJsonInput } from "../utils/sanitization";
 import DropdownMenu from "./DropdownMenu";
 import EnrollmentError from "./EnrollmentError";
 
@@ -21,7 +22,9 @@ const FeatureConfigPage: FC = () => {
 
   const handleInputChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
-      setJsonInput(event.target.value);
+      const rawValue = event.target.value;
+      const sanitizedValue = sanitizeJsonInput(rawValue);
+      setJsonInput(sanitizedValue);
     },
     [],
   );

--- a/src/ui/components/RecipeEnrollmentPage.tsx
+++ b/src/ui/components/RecipeEnrollmentPage.tsx
@@ -2,6 +2,7 @@ import { ChangeEvent, FC, useState, useCallback } from "react";
 import { Form, Container, Button, Modal } from "react-bootstrap";
 
 import { useToastsContext } from "../hooks/useToasts";
+import { sanitizeJsonInput } from "../utils/sanitization";
 import EnrollmentError from "./EnrollmentError";
 
 type EnrollError = EnrollInExperimentResult["error"] & { slug: string };
@@ -14,7 +15,9 @@ const RecipeEnrollmentPage: FC = () => {
 
   const handleInputChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
-      setJsonInput(event.target.value);
+      const rawValue = event.target.value;
+      const sanitizedValue = sanitizeJsonInput(rawValue);
+      setJsonInput(sanitizedValue);
     },
     [setJsonInput],
   );

--- a/src/ui/utils/sanitization.ts
+++ b/src/ui/utils/sanitization.ts
@@ -1,0 +1,10 @@
+/**
+* Sanitizes a JSON string:
+* 1. replace invalid quote characters with valid double quotes.
+*
+* @param input - The raw JSON string potentially containing invalid quote characters.
+* @returns A sanitized JSON string with all quotes converted to valid double quotes.
+*/
+export function sanitizeJsonInput(input: string): string {
+  return input.replace(/[“”‘’]/g, '"');
+};


### PR DESCRIPTION
The feature config page gave an unclear error when JSON was copy-pasted from a Google Doc which used left/right-double-quote characters. This updates to the code to automatically convert quote characters into valid JSON double-quote characters.

Note: When I tried to spot-check the recipe enrollment page, it didn't seem to let me put any input into the textarea at all?