### PR TITLE
Improve wording clarity of "Refresh Context" button

### DIFF
--- a/src/ui/components/JEXLDebuggerPage.tsx
+++ b/src/ui/components/JEXLDebuggerPage.tsx
@@ -315,7 +315,7 @@ const JEXLDebuggerPage: FC = () => {
             onClick={fetchClientContext}
             className="option-button primary-fg py-2 px-3 rounded small-font fw-bold mb-3 grey-border light-bg"
           >
-            Refresh Context
+            Reset Context
           </Button>
           {Object.entries(originalContext).map(([key]) => (
             <Row key={key} className="mb-4 d-flex align-items-center">


### PR DESCRIPTION
Renames the "Refresh Context" button on the JEXL Debugger to be "Reset Context" instead for better clarity.

Fixes #71