### PR TITLE
Correctly import ExtensionError

### DIFF
--- a/src/apis/.eslintrc.js
+++ b/src/apis/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
   plugins: ["mozilla"],
   globals: {
     ExtensionAPI: true,
-    ExtensionError: true,
+    ExtensionUtils: true,
   },
   rules: {
     "no-unused-vars": ["error", { varsIgnorePattern: "nimbus" }],

--- a/src/apis/nimbus.js
+++ b/src/apis/nimbus.js
@@ -23,6 +23,7 @@ ChromeUtils.defineESModuleGetters(lazy, {
 
 var nimbus = class extends ExtensionAPI {
   getAPI() {
+    const { ExtensionError } = ExtensionUtils;
     return {
       experiments: {
         nimbus: {


### PR DESCRIPTION
It is not a global -- it is defined as part of ExtensionUtils.

Fixes #90