### PR TITLE
Don't import ExperimentAPI or RemoteSettingsExperimentLoader directly

### DIFF
--- a/src/apis/nimbus.js
+++ b/src/apis/nimbus.js
@@ -12,14 +12,22 @@ ChromeUtils.defineESModuleGetters(lazy, {
   ClientEnvironmentBase:
     "resource://gre/modules/components-utils/ClientEnvironment.sys.mjs",
   ExperimentAPI: "resource://nimbus/ExperimentAPI.sys.mjs",
-  ExperimentManager: "resource://nimbus/lib/ExperimentManager.sys.mjs",
   FilterExpressions:
     "resource://gre/modules/components-utils/FilterExpressions.sys.mjs",
   NimbusFeatures: "resource://nimbus/ExperimentAPI.sys.mjs",
-  RemoteSettingsExperimentLoader:
-    "resource://nimbus/lib/RemoteSettingsExperimentLoader.sys.mjs",
   TelemetryEnvironment: "resource://gre/modules/TelemetryEnvironment.sys.mjs",
 });
+
+ChromeUtils.defineLazyGetter(
+  lazy,
+  "ExperimentManager",
+  () => lazy.ExperimentAPI._manager,
+);
+ChromeUtils.defineLazyGetter(
+  lazy,
+  "RemoteSettingsExperimentLoader",
+  () => lazy.ExperimentAPI._rsLoader,
+);
 
 var nimbus = class extends ExtensionAPI {
   getAPI() {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,7 +5,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "nimbus-devtools@mozilla.com",
-      "strict_min_version": "113.0.a1"
+      "strict_min_version": "137.0.a1"
     }
   },
   "permissions": ["mozillaAddons"],


### PR DESCRIPTION
We have to stop using these ESMs directly because they are changing from
exporting singletons to just the classes. See [bug 1950237][1] and [bug
1907633][2].

[1]: https://bugzilla.mozilla.org/show_bug.cgi?id=1950237 
[2]: https://bugzilla.mozilla.org/show_bug.cgi?id=1907633

Fixes https://github.com/mozilla-extensions/nimbus-devtools/issues/86