### PR TITLE
Allow enrollment in experiments and rollouts via devtools

### DIFF
--- a/src/apis/nimbus.js
+++ b/src/apis/nimbus.js
@@ -37,15 +37,19 @@ var nimbus = class extends ExtensionAPI {
         nimbus: {
           async enrollInExperiment(jsonData, forceEnroll) {
             try {
+              const { slug, isRollout = false } = jsonData;
+
               const slugExistsInStore = lazy.ExperimentManager.store
                 .getAll()
-                .some((experiment) => experiment.slug === jsonData.slug);
+                .some((experiment) => experiment.slug === slug);
               const activeEnrollment =
                 lazy.ExperimentManager.store
                   .getAll()
                   .find(
                     (experiment) =>
-                      experiment.slug === jsonData.slug && experiment.active,
+                      experiment.slug === slug &&
+                      experiment.isRollout === isRollout &&
+                      experiment.active,
                   )?.slug ?? null;
               if (slugExistsInStore || activeEnrollment) {
                 if (!forceEnroll) {
@@ -124,6 +128,7 @@ var nimbus = class extends ExtensionAPI {
                   .find(
                     (experiment) =>
                       experiment.featureIds.includes(featureId) &&
+                      experiment.isRollout === isRollout &&
                       experiment.active,
                   )?.slug ?? null;
 


### PR DESCRIPTION
When we were checking for a previous enrollment, we weren't checking for the right type of enrollment (rollout vs experiment) so if there was an active experiment you couldn't enroll in a rollout without triggering unenrollment of the experiment (and vice versa). As a result we also got the name of the enrollment we were trying to enroll incorrect in the dialog.

Fixes #101