### PR TITLE
Clean up our hook dependency arrays

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "eslint-plugin-import": "^2.28.0",
         "eslint-plugin-mozilla": "^3.1.0",
         "eslint-plugin-react": "^7.33.1",
+        "eslint-plugin-react-hooks": "^5.2.0",
         "npm-run-all": "^4.1.5",
         "parcel": "^2.9.3",
         "prettier": "^3.0.0",
@@ -5254,6 +5255,19 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-import": "^2.28.0",
     "eslint-plugin-mozilla": "^3.1.0",
     "eslint-plugin-react": "^7.33.1",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "npm-run-all": "^4.1.5",
     "parcel": "^2.9.3",
     "prettier": "^3.0.0",

--- a/src/ui/.eslintrc.js
+++ b/src/ui/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
     "plugin:import/typescript",
     "plugin:react/recommended",
     "plugin:react/jsx-runtime",
+    "plugin:react-hooks/recommended-legacy",
   ],
   env: {
     es2023: true,
@@ -40,5 +41,6 @@ module.exports = {
         ignoreRestArgs: true,
       },
     ],
+    "react-hooks/exhaustive-deps": "error",
   },
 };

--- a/src/ui/components/DropdownMenu.tsx
+++ b/src/ui/components/DropdownMenu.tsx
@@ -25,9 +25,12 @@ const DropdownMenu: FC<DropdownMenuProps> = ({ onSelectFeatureConfigId }) => {
     })();
   }, [addToast]);
 
-  const handleChange = useCallback((event: ChangeEvent<HTMLSelectElement>) => {
-    onSelectFeatureConfigId(event.target.value);
-  }, []);
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      onSelectFeatureConfigId(event.target.value);
+    },
+    [onSelectFeatureConfigId],
+  );
 
   return (
     <Form.Group controlId="featureConfigSelect">

--- a/src/ui/components/ExperimentBrowserPage.tsx
+++ b/src/ui/components/ExperimentBrowserPage.tsx
@@ -48,7 +48,7 @@ const ExperimentRow: FC<{ experiment: NimbusExperiment }> = ({
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       setSelectedBranch(e.target.value);
     },
-    [setSelectedBranch],
+    [],
   );
 
   const handleGenerateTestIds = useCallback(async () => {

--- a/src/ui/components/ExperimentStorePage.tsx
+++ b/src/ui/components/ExperimentStorePage.tsx
@@ -27,7 +27,7 @@ const ExperimentStorePage: FC = () => {
         variant: "danger",
       });
     }
-  }, [experiments, addToast]);
+  }, [addToast]);
 
   useEffect(() => {
     void fetchExperiments();

--- a/src/ui/components/FeatureConfigPage.tsx
+++ b/src/ui/components/FeatureConfigPage.tsx
@@ -80,11 +80,11 @@ const FeatureConfigPage: FC = () => {
   const handleModalConfirm = useCallback(async () => {
     setEnrollError(null);
     await handleEnrollClick(null, true);
-  }, [handleEnrollClick, setEnrollError]);
+  }, [handleEnrollClick]);
 
   const handleModalClose = useCallback(() => {
     setEnrollError(null);
-  }, [setEnrollError]);
+  }, []);
 
   return (
     <Container className="main-content p-2 overflow-hidden">

--- a/src/ui/components/JEXLDebuggerPage.tsx
+++ b/src/ui/components/JEXLDebuggerPage.tsx
@@ -178,7 +178,7 @@ const JEXLDebuggerPage: FC = () => {
 
   useEffect(() => {
     void fetchClientContext();
-  }, []);
+  }, [fetchClientContext]);
 
   const handleExpressionChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
@@ -237,7 +237,7 @@ const JEXLDebuggerPage: FC = () => {
         }
       }
     }, 1000);
-  }, [addToast, setModifiedContext]);
+  }, [addToast]);
 
   const handleContextChange = useCallback<OnChangeFn>(
     (key: string, value: FormDataValue, fieldType: FieldType) => {
@@ -276,7 +276,7 @@ const JEXLDebuggerPage: FC = () => {
         [key]: value,
       }));
     },
-    [setModifiedContext, setFormData, parseAndSetContext],
+    [parseAndSetContext],
   );
 
   return (

--- a/src/ui/components/RecipeEnrollmentPage.tsx
+++ b/src/ui/components/RecipeEnrollmentPage.tsx
@@ -16,7 +16,7 @@ const RecipeEnrollmentPage: FC = () => {
     (event: ChangeEvent<HTMLTextAreaElement>) => {
       setJsonInput(event.target.value);
     },
-    [setJsonInput],
+    [],
   );
 
   const handleEnrollClick = useCallback(
@@ -63,17 +63,17 @@ const RecipeEnrollmentPage: FC = () => {
         });
       }
     },
-    [jsonInput, setJsonInput, addToast, setEnrollError],
+    [jsonInput, addToast],
   );
 
   const handleModalConfirm = useCallback(async () => {
     setEnrollError(null);
     await handleEnrollClick(undefined, true);
-  }, [handleEnrollClick, setEnrollError]);
+  }, [handleEnrollClick]);
 
   const handleModalClose = useCallback(() => {
     setEnrollError(null);
-  }, [setEnrollError]);
+  }, []);
 
   return (
     <Container className="main-content m-0 p-2">

--- a/src/ui/components/SettingsPage.tsx
+++ b/src/ui/components/SettingsPage.tsx
@@ -58,7 +58,7 @@ const SettingsPage: FC = () => {
         }
       }
     },
-    [customCollection, collectionId, setCollectionId, addToast],
+    [customCollection, addToast],
   );
 
   const handleCustomChange = useCallback(
@@ -76,7 +76,7 @@ const SettingsPage: FC = () => {
         }
       }
     },
-    [collectionId, customCollection, setCustomCollection, addToast],
+    [collectionId, addToast],
   );
 
   const handleForceSyncChange = useCallback(
@@ -96,7 +96,7 @@ const SettingsPage: FC = () => {
         variant: "danger",
       });
     }
-  }, [forceSync, setForceSync, addToast]);
+  }, [forceSync, addToast]);
 
   return (
     <Container fluid className="main-content py-4 p-2 overflow-hidden">


### PR DESCRIPTION
This change adds the `eslint-plugin-react-hooks` plugin to ensure that our hook dependency arrays stay up to date. Additionally, I went and cleaned up all our dependency arrays that were capturing state setters because it turns out you don't need to include those in your dependencies because they never change.