### PR TITLE
Return the result of evaluateJEXL directly

### DIFF
--- a/src/ui/jexlParser.ts
+++ b/src/ui/jexlParser.ts
@@ -96,11 +96,7 @@ async function evaluateExpression(
   context: object,
 ): Promise<object | boolean> {
   try {
-    const result = await browser.experiments.nimbus.evaluateJEXL(
-      expression,
-      context,
-    );
-    return result === null ? true : result;
+    return await browser.experiments.nimbus.evaluateJEXL(expression, context);
   } catch (error) {
     console.error(`Error evaluating part "${expression}":`, error);
     throw error;


### PR DESCRIPTION
The regExpMatch filter expression returns null on no match (e.g., "1"|regExpMatch("2") == null), which leads to surprising results. Return result instead.

Fixes #117