### PR TITLE
Update browserslist in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
       "source": "./src/ui/index.html"
     }
   },
-  "browserslist": "firefox 113",
+  "browserslist": [
+    "firefox > 137",
+    "unreleased firefox versions"
+  ],
   "scripts": {
     "build": "npm-run-all clean build:manifest build:ui build:package",
     "build:ui": "parcel build --target ui",


### PR DESCRIPTION
We require Firefox 137.0.a1 in the webextension manifest. However, the previous browserslist entry supported ONLY Firefox 137.