### PR TITLE
Specify browsers for parcel to target

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,13 @@
     "ui": {
       "distDir": "./dist/ui",
       "publicUrl": "./",
-      "source": "./src/ui/index.html"
+      "source": "./src/ui/index.html",
+      "engines": {
+        "browsers": [
+          "firefox > 137",
+          "unreleased firefox versions"
+        ]
+      }
     }
   },
   "browserslist": [


### PR DESCRIPTION
If engines is provided in package.json, parcel will use that as the default engine for all targets. When we added the engines field in 573084fbcc2e2b08fd2f1dcccafda27cd2c51f9e we broke the bundling step. Manually specifying the target browser (in browserslist format) fixes it.