### PR TITLE
Require type for type definitions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -139,6 +139,7 @@ export default defineConfig([
           ignoreRestArgs: true,
         },
       ],
+      "@typescript-eslint/consistent-type-definitions": ["error", "type"],
       "react-hooks/exhaustive-deps": "error",
     },
   },

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -9,27 +9,27 @@ declare module "*.png" {
 }
 
 declare module "mozjexl/lib/grammar" {
-  export interface GrammarItem {
+  export type GrammarItem = {
     type: string;
     precedence?: number;
     eval?: (
       left: boolean | number | string,
       right?: boolean | number | string,
     ) => boolean | number | string;
-  }
+  };
 
-  export interface Grammar {
+  export type Grammar = {
     elements: {
       [key: string]: GrammarItem;
     };
-  }
+  };
 
-  export interface Token {
+  export type Token = {
     type: string;
     name?: string;
     value: boolean | number | string;
     raw: string;
-  }
+  };
 
   export const elements: Grammar;
 }

--- a/src/ui/components/ExperimentStorePage.tsx
+++ b/src/ui/components/ExperimentStorePage.tsx
@@ -3,14 +3,14 @@ import { Table, Button, Container } from "react-bootstrap";
 
 import { useToastsContext } from "../hooks/useToasts";
 
-interface NimbusEnrollment {
+type NimbusEnrollment = {
   slug: string;
   userFacingName: string;
   userFacingDescription: string;
   isRollout: boolean;
   featureIds: string[];
   active: boolean;
-}
+};
 
 const ExperimentStorePage: FC = () => {
   const [experiments, setExperiments] = useState<NimbusEnrollment[]>([]);

--- a/src/ui/hooks/useToasts.ts
+++ b/src/ui/hooks/useToasts.ts
@@ -1,17 +1,17 @@
 import { createContext, useCallback, useContext, useState } from "react";
 
-export interface Toast {
+export type Toast = {
   id: string;
   message: string;
   variant: "success" | "danger";
   autohide?: boolean;
-}
+};
 
-export interface UseToasts {
+export type UseToasts = {
   toasts: Toast[];
   addToast: (params: AddToastParams) => void;
   removeToast: (id: string) => void;
-}
+};
 
 export type AddToastParams = {
   message: string;


### PR DESCRIPTION
Interface definitions are subtly different from types created with type (e.g., due to [declration merging][1]). typescript-eslint provides a lint for this, so let's enable it.

[1]: https://www.typescriptlang.org/docs/handbook/declaration-merging.html