### PR TITLE
Fix logo in navbar

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -3,11 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-declare module "*.png" {
-  const value: string;
-  export default value;
-}
-
 declare module "mozjexl/lib/grammar" {
   export type GrammarItem = {
     type: string;

--- a/src/ui/components/NavigationBar.tsx
+++ b/src/ui/components/NavigationBar.tsx
@@ -2,13 +2,13 @@ import { FC } from "react";
 import { Link } from "react-router-dom";
 import { Navbar, Container } from "react-bootstrap";
 
-import logo from "../static/logo.png";
+const logoUrl = String(new URL("../static/logo.png", import.meta.url));
 
 const NavigationBar: FC = () => {
   return (
     <Navbar className="p-2">
       <Container className="d-flex justify-content-start align-items-center ms-3 py-1">
-        <img alt="logo" src={logo} width="32" className="me-2" />
+        <img alt="logo" src={logoUrl} width="32" className="me-2" />
         <Link
           to="/experiment-json"
           className="ms-2 text-white text-decoration-none fs-3"


### PR DESCRIPTION
The logo broke in 15f824e5, which updated some parcel-related dependencies. Importing images is now done by creating a `new URL()` and passing the `import.meta.url` as the base for the URL.