### PR TITLE
Use ExperimentAPI.manager directly

### DIFF
--- a/src/apis/nimbus.js
+++ b/src/apis/nimbus.js
@@ -24,7 +24,7 @@ ChromeUtils.defineESModuleGetters(lazy, {
 ChromeUtils.defineLazyGetter(
   lazy,
   "ExperimentManager",
-  () => lazy.ExperimentAPI._manager,
+  () => lazy.ExperimentAPI.manager,
 );
 ChromeUtils.defineLazyGetter(
   lazy,


### PR DESCRIPTION
`ExperimentAPI._manager` is deprecated and only exists to not break nimbus-devtools.

Fixes #145