### PR TITLE
Use the new cause-based unenrollment API

### DIFF
--- a/src/apis/nimbus.js
+++ b/src/apis/nimbus.js
@@ -340,10 +340,9 @@ var nimbus = class extends ExtensionAPI {
 
           async unenroll(slug) {
             try {
-              return await lazy.ExperimentManager.unenroll(
-                slug,
-                "nimbus-devtools",
-              );
+              return await lazy.ExperimentManager.unenroll(slug, {
+                reason: "nimbus-devtools",
+              });
             } catch (error) {
               console.error(error);
               throw new ExtensionError(String(error));


### PR DESCRIPTION
The `ExperimentManager.unenroll()` API changed in Firefox 139 (see-also [1]), which now takes a more well-defined object instead of a grab bag of properties.

Fixes #91

[1]: https://bugzilla.mozilla.org/show_bug.cgi?id=1955169