### PR TITLE
Fix watch:manifest script

### DIFF
--- a/bin/build-manifest.mjs
+++ b/bin/build-manifest.mjs
@@ -88,6 +88,7 @@ function watch() {
 
       ({ manifest, files } = parseManifest({ dev: true }));
 
+      copyFiles(files);
       fs.writeFileSync(
         path.join(DIST_DIR, MANIFEST),
         JSON.stringify(manifest, null, 2),


### PR DESCRIPTION
Commit 0944b8def793d272413a2092bfde785d2d1b079d broke the script while refactoring `parseManifest()` to return the manifest for modification.