### PR TITLE
Support force enrollment on Experimenter

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -13,7 +13,6 @@ browser.browserAction.onClicked.addListener(() =>
 
 browser.runtime.onMessage.addListener(
   function (message, _sender, sendResponse) {
-    console.log(message);
     if (
       typeof message !== "object" ||
       message === null ||
@@ -24,13 +23,20 @@ browser.runtime.onMessage.addListener(
     }
 
     switch (message.kind) {
+      case MessageKind.FORCE_ENROLL:
+        browser.experiments.nimbus
+          .forceEnroll(message.recipe, message.branchSlug)
+          .then(
+            () => sendResponse({}),
+            (error) => sendResponse({ error }),
+          );
+
+        return true;
+
       case MessageKind.GET_MESSAGING_FEATURES_AND_TEMPLATES:
         browser.experiments.messagingSystem
           .getMessagingFeaturesAndTemplates()
-          .then((v) => {
-            console.log("rv", v);
-            sendResponse(v);
-          });
+          .then((v) => sendResponse(v));
 
         return true;
 

--- a/src/background/messages.js
+++ b/src/background/messages.js
@@ -4,6 +4,7 @@
  */
 
 export const MessageKind = Object.freeze({
+  FORCE_ENROLL: "nimbus-devtools:forceEnroll",
   GET_MESSAGING_FEATURES_AND_TEMPLATES:
     "nimbus-devtools:getMessagingFeaturesAndTemplates",
   PREVIEW_MESSAGE: "nimbus-devtools:previewMessage",

--- a/src/contentScripts/experimenter.js
+++ b/src/contentScripts/experimenter.js
@@ -81,6 +81,29 @@ class ExperimenterIntegration {
    */
   handleSummaryPage() {
     document
+      .querySelector("[data-nimbus-devtools-preview-url-pane]")
+      ?.classList.add("d-none");
+
+    document
+      .querySelectorAll("[data-nimbus-devtools-opt-in-pane]")
+      .forEach((pane) => {
+        pane
+          .querySelector("[data-nimbus-devtools-enroll-button]")
+          .addEventListener("click", () => {
+            const recipe = JSON.parse(
+              document.querySelector(
+                "[data-nimbus-devtools-recipe-json] textarea",
+              ).value,
+            );
+            const branchSlug = pane.querySelector("[name='branch']")?.value;
+
+            this.forceEnroll(recipe, branchSlug);
+          });
+
+        pane.classList.remove("d-none");
+      });
+
+    document
       .querySelectorAll("textarea[data-nimbus-devtools-feature-value]")
       .forEach((el) => {
         if (!this.featureIds.includes(el.dataset.featureId)) {
@@ -150,6 +173,22 @@ class ExperimenterIntegration {
     });
 
     insertControls();
+  }
+
+  async forceEnroll(recipe, branchSlug) {
+    try {
+      await browser.runtime.sendMessage({
+        kind: MessageKind.FORCE_ENROLL,
+        recipe,
+        branchSlug,
+      });
+
+      this.createAndShowToast("Enrolled", { classList: ["text-bg-success"] });
+    } catch (error) {
+      this.createAndShowToast(`Could not enroll: ${error}`, {
+        classList: ["text-bg-danger"],
+      });
+    }
   }
 
   async tryPreviewMessage(message) {


### PR DESCRIPTION
The experimenter half of this integration is at
mozilla/experimenter#14958, which defines some extra elements in the DOM that nimbus-devtools can show to support one-click opt-in.

Fixes #63