### PR TITLE
Remove hidden added toasts from DOM correctly

### DIFF
--- a/src/contentScripts/experimenter.js
+++ b/src/contentScripts/experimenter.js
@@ -225,8 +225,12 @@ class ExperimenterIntegration {
       }
     }
 
-    el.addEventListener("hidden.bs.toast", () => document.body.removeChild(el));
-    document.getElementById("toasts-container").appendChild(el);
+    const toastContainer = document.getElementById("toasts-container");
+
+    el.addEventListener("hidden.bs.toast", () =>
+      toastContainer.removeChild(el),
+    );
+    toastContainer.appendChild(el);
 
     new window.wrappedJSObject.bootstrap.Toast(el).show();
   }


### PR DESCRIPTION
We added support for showing toasts in commit
0944b8def793d272413a2092bfde785d2d1b079d, but mistakenly were attempting to remove them from the `<body>` instead of the toasts container.