### PR TITLE
Correct strict_min_version in manifest.json

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,7 +5,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "nimbus-devtools@mozilla.com",
-      "strict_min_version": "150.0.a1",
+      "strict_min_version": "150.0a1",
       "data_collection_permissions": {
         "required": ["none"]
       }


### PR DESCRIPTION
There was a typo in the strict_min_version, which made the addon incompatible with Nightly 150. This did not affect local development because addon compatability is disabled by default in that environment, but would have become an issue when we shipped the addon.