### PR TITLE
Expose version as __NIMBUS_DEVTOOLS__.version

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -63,6 +63,9 @@ export default defineConfig([
       globals: {
         ...globals.browser,
         ...globals.webextensions,
+
+        // Parcel exposes `process.env` at compile time.
+        process: true,
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
       "distDir": "./dist/contentScripts",
       "publicUrl": "./",
       "source": [
-        "./src/contentScripts/experimenter.js"
+        "./src/contentScripts/experimenter.js",
+        "./src/contentScripts/devtools.js"
       ],
       "outputFormat": "esmodule"
     },
@@ -30,6 +31,11 @@
     "firefox >= 150",
     "unreleased firefox versions"
   ],
+  "@parcel/transformer-js": {
+    "inlineEnvironment": [
+      "npm_package_version"
+    ]
+  },
   "scripts": {
     "build": "npm-run-all clean build:manifest build:parcel build:package",
     "build:parcel": "parcel build --no-autoinstall",

--- a/src/contentScripts/devtools.js
+++ b/src/contentScripts/devtools.js
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+window.wrappedJSObject.__NIMBUS_DEVTOOLS__ = window.structuredClone({
+  version:
+    process.env.npm_package_version?.split(".").map((v) => parseInt(v)) ?? null,
+});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,6 +25,14 @@
         "https://experimenter.services.mozilla.com/*",
         "https://stage.experimenter.nonprod.webservices.mozgcp.net/*"
       ],
+      "run_at": "document_start",
+      "js": ["contentScripts/devtools.js"]
+    },
+    {
+      "matches": [
+        "https://experimenter.services.mozilla.com/*",
+        "https://stage.experimenter.nonprod.webservices.mozgcp.net/*"
+      ],
       "js": ["contentScripts/experimenter.js"]
     }
   ],


### PR DESCRIPTION
Sites that nimbus-devtools integrates with (i.e., Experimenter) can now inspect the version of nimbus-devtools installed via the `window.__NIMBUS_DEVTOOLS__` global. It is exposed as a 3-tuple of the version number (major, minor, patch).