### PR TITLE
Fix type of previewMessage() API in global.d.ts

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -113,7 +113,7 @@ type MessagingFeaturesAndTemplates = {
 declare namespace browser.experiments.messagingSystem {
   function getMessagingFeaturesAndTemplates(): Promise<null | MessagingFeaturesAndTemplates>;
 
-  function previewMessage(string): Promise<void>;
+  function previewMessage(messageContent: string): Promise<void>;
 }
 
 type EnrollInExperimentResult =


### PR DESCRIPTION
The function type was missing the variable name, so it was implicitly setting `string: any` instead of `argument: string`.