### PR TITLE
Use modals for force-enrollment and generating test IDs

### DIFF
--- a/src/apis/nimbus.js
+++ b/src/apis/nimbus.js
@@ -355,10 +355,9 @@ var nimbus = class extends ExtensionAPI {
             }
           },
 
-          async generateTestIds(recipe, branchSlug) {
+          async generateTestIds(recipe) {
             try {
-              const result = await ExperimentManager.generateTestIds(recipe);
-              return result[branchSlug];
+              return await ExperimentManager.generateTestIds(recipe);
             } catch (error) {
               console.error(error);
               throw new ExtensionError(String(error));

--- a/src/apis/nimbus.json
+++ b/src/apis/nimbus.json
@@ -176,19 +176,14 @@
       {
         "name": "generateTestIds",
         "type": "function",
-        "description": "Generate Normandy UserId respective to a branch for a specific experiment.",
+        "description": "Generate test IDs for all branches of an experiment.",
         "async": true,
         "parameters": [
           {
             "name": "recipe",
             "type": "object",
             "additionalProperties": true,
-            "description": "The recipe of the experiment to generate the UserId for."
-          },
-          {
-            "name": "branchSlug",
-            "type": "string",
-            "description": "The specific branch slug of the experiment."
+            "description": "The recipe of the experiment to generate the IDs for."
           }
         ]
       },

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -162,7 +162,7 @@ declare namespace browser.experiments.nimbus {
 
   function deleteInactiveEnrollment(slug: string): Promise<void>;
 
-  function generateTestIds(recipe: object, branchSlug: string): Promise<string>;
+  function generateTestIds(recipe: object): Promise<Record<string, string>>;
 
   function substituteLocalizations(
     values: Record<string, unknown>,

--- a/src/ui/components/ExperimentBrowserPage.tsx
+++ b/src/ui/components/ExperimentBrowserPage.tsx
@@ -1,4 +1,11 @@
-import { FC, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ChangeEvent,
+  FC,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { NimbusExperiment } from "@mozilla/nimbus-schemas";
 import {
   Table,
@@ -8,11 +15,21 @@ import {
   Row,
   Col,
   Dropdown,
+  Modal,
 } from "react-bootstrap";
 
 import { AddToastParams, useToastsContext } from "../hooks/useToasts";
 
 type Status = "Live" | "Preview";
+type DialogState =
+  | {
+      kind: "force-enroll";
+      experiment: NimbusExperiment;
+    }
+  | {
+      kind: "generate-test-ids";
+      experiment: NimbusExperiment;
+    };
 
 enum Environment {
   PROD = "prod",
@@ -26,43 +43,194 @@ const EXPERIMENTER_API = {
     "https://stage.experimenter.nonprod.webservices.mozgcp.net/api/v6/experiments/",
 };
 
-const ExperimentRow: FC<{
-  environment: Environment;
-  experiment: NimbusExperiment;
-}> = ({ environment, experiment }) => {
-  const { addToast } = useToastsContext();
-  const branchSlugs = useMemo(
-    () => experiment.branches?.map((b) => b.slug),
-    [experiment],
-  );
-  const [selectedBranch, setSelectedBranch] = useState<string>("");
+type DialogProps = {
+  closeDialog: () => void;
+  experiment: NimbusExperiment | null;
+};
 
-  const branchSlugOptions = useMemo(
+type ForceEnrollmentDialogProps = DialogProps & { environment: Environment };
+
+const ForceEnrollmentDialog: FC<ForceEnrollmentDialogProps> = ({
+  environment,
+  closeDialog,
+  experiment,
+}) => {
+  const { addToast } = useToastsContext();
+
+  // If there is only a single branch, default to it.
+  const [selectedBranch, setSelectedBranch] = useState<string>(
+    experiment?.branches?.length === 1 ? experiment.branches[0].slug : "",
+  );
+
+  const branchOptions = useMemo(
     () =>
-      branchSlugs.map((slug) => (
-        <option key={slug} value={slug}>
-          {slug}
+      experiment?.branches?.map((branch) => (
+        <option value={branch.slug} key={branch.slug}>
+          {branch.slug}
         </option>
       )),
-    [branchSlugs],
+    [experiment],
   );
 
-  const onSelectedBranchChanged = useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) => {
-      setSelectedBranch(e.target.value);
-    },
+  const onBranchSelected = useCallback(
+    (e: ChangeEvent<HTMLSelectElement>) => setSelectedBranch(e.target.value),
     [],
   );
 
-  const handleGenerateTestIds = useCallback(async () => {
-    const toast = await tryGenerateTestId(experiment, selectedBranch);
-    addToast(toast);
-  }, [experiment, selectedBranch, addToast]);
-
   const handleEnroll = useCallback(async () => {
-    const toast = await tryEnroll(environment, experiment.slug, selectedBranch);
-    addToast(toast);
-  }, [environment, experiment, selectedBranch, addToast]);
+    if (experiment && selectedBranch) {
+      const toast = await tryEnroll(
+        environment,
+        experiment.slug,
+        selectedBranch,
+      );
+      addToast(toast);
+      closeDialog();
+    }
+  }, [environment, experiment, selectedBranch, addToast, closeDialog]);
+
+  return (
+    <Modal show={experiment !== null} onHide={closeDialog}>
+      <Modal.Header closeButton>
+        <Modal.Title>Force Enroll</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Form.Select value={selectedBranch ?? ""} onChange={onBranchSelected}>
+          <option value="">Select branch...</option>
+          {branchOptions}
+        </Form.Select>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={closeDialog}>
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          onClick={handleEnroll}
+          disabled={selectedBranch === ""}
+        >
+          Enroll
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+const GenerateTestIdsDialog: FC<DialogProps> = ({
+  closeDialog,
+  experiment,
+}) => {
+  const { addToast } = useToastsContext();
+
+  const [testIds, setTestIds] = useState<Record<string, string> | null>(null);
+
+  const handleCopyClicked = useCallback(
+    async (slug: string) => {
+      if (testIds?.[slug]) {
+        await navigator.clipboard.writeText(testIds[slug]);
+
+        addToast({
+          message: "ID copied to clipboard.",
+          variant: "success",
+        });
+      }
+    },
+    [testIds, addToast],
+  );
+
+  const handleCopyAllClicked = useCallback(async () => {
+    if (testIds) {
+      await navigator.clipboard.writeText(JSON.stringify(testIds));
+
+      addToast({
+        message: "IDs copied to clipboard.",
+        variant: "success",
+      });
+    }
+  }, [testIds, addToast]);
+
+  useEffect(() => {
+    if (experiment) {
+      browser.experiments.nimbus.generateTestIds(experiment).then(
+        (result) => setTestIds(result),
+        () => {
+          addToast({
+            message: "Test ID generation failed",
+            variant: "danger",
+          });
+
+          closeDialog();
+        },
+      );
+    }
+  }, [experiment, addToast, closeDialog]);
+
+  const rows = useMemo(
+    () =>
+      experiment?.branches?.map((branch) => (
+        <tr key={branch.slug}>
+          <td>{branch.slug}</td>
+          <td>
+            <Button
+              className="btn-sm"
+              onClick={() => handleCopyClicked(branch.slug)}
+              disabled={testIds === null}
+            >
+              Copy
+            </Button>
+          </td>
+        </tr>
+      )),
+    [experiment, testIds, handleCopyClicked],
+  );
+
+  return (
+    <Modal show={experiment !== null} onHide={closeDialog}>
+      <Modal.Header closeButton>
+        <Modal.Title>Test IDs</Modal.Title>
+      </Modal.Header>
+
+      <Modal.Body>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Branch</th>
+              <th>Copy</th>
+            </tr>
+          </thead>
+          <tbody>{rows}</tbody>
+        </table>
+      </Modal.Body>
+
+      <Modal.Footer>
+        <Button variant="secondary" onClick={closeDialog}>
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          onClick={handleCopyAllClicked}
+          disabled={testIds === null}
+        >
+          Copy All as JSON
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+const ExperimentRow: FC<{
+  experiment: NimbusExperiment;
+  openForceEnrollDialog: (e: NimbusExperiment) => void;
+  openGenerateTestIdsDialog: (e: NimbusExperiment) => void;
+}> = ({ experiment, openForceEnrollDialog, openGenerateTestIdsDialog }) => {
+  const handleForceEnrollClicked = useCallback(
+    () => openForceEnrollDialog(experiment),
+    [openForceEnrollDialog, experiment],
+  );
+  const handleGenerateTestIdsClicked = useCallback(
+    () => openGenerateTestIdsDialog(experiment),
+    [openGenerateTestIdsDialog, experiment],
+  );
 
   return (
     <tr>
@@ -74,32 +242,18 @@ const ExperimentRow: FC<{
       <td className="text-center align-middle px-2">
         {experiment.isEnrollmentPaused ? "Enrollment Paused" : "Enrolling"}
       </td>
-      <td className="text-end align-middle wide-column">
-        <Container className="d-flex align-items-center">
-          <Form.Select
-            value={selectedBranch}
-            onChange={onSelectedBranchChanged}
-            className="grey-border small-font rounded p-2 m-0 font-monospace"
-          >
-            <option value="">Select branch</option>
-            {branchSlugOptions}
-          </Form.Select>
-          <Dropdown>
-            <Dropdown.Toggle
-              variant={!selectedBranch ? "secondary" : "primary"}
-              className="option-button primary-fg mx-2 py-2 px-3 rounded small-font fw-bold grey-border light-bg"
-              disabled={!selectedBranch}
-            >
-              Actions
-            </Dropdown.Toggle>
-            <Dropdown.Menu>
-              <Dropdown.Item onClick={handleEnroll}>Force Enroll</Dropdown.Item>
-              <Dropdown.Item onClick={handleGenerateTestIds}>
-                Generate Test IDs
-              </Dropdown.Item>
-            </Dropdown.Menu>
-          </Dropdown>
-        </Container>
+      <td className="text-center align-middle px-2">
+        <Dropdown>
+          <Dropdown.Toggle>Actions</Dropdown.Toggle>
+          <Dropdown.Menu>
+            <Dropdown.Item onClick={handleForceEnrollClicked}>
+              Force Enroll...
+            </Dropdown.Item>
+            <Dropdown.Item onClick={handleGenerateTestIdsClicked}>
+              Generate Test IDs...
+            </Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>
       </td>
     </tr>
   );
@@ -142,69 +296,101 @@ const ExperimentBrowserPage: FC = () => {
     void fetchExperiments();
   }, [fetchExperiments]);
 
+  const [dialogState, setDialogState] = useState<DialogState | null>(null);
+  const openForceEnrollmentDialog = useCallback(
+    (experiment: NimbusExperiment) =>
+      setDialogState({ kind: "force-enroll", experiment }),
+    [],
+  );
+  const openGenerateTestIdsDialog = useCallback(
+    (experiment: NimbusExperiment) =>
+      setDialogState({ kind: "generate-test-ids", experiment }),
+    [],
+  );
+  const closeDialog = useCallback(() => setDialogState(null), []);
+
   const experimentRows = useMemo(
     () =>
       experiments.map((experiment) => (
         <ExperimentRow
           key={experiment.slug}
-          environment={environment}
           experiment={experiment}
+          openForceEnrollDialog={openForceEnrollmentDialog}
+          openGenerateTestIdsDialog={openGenerateTestIdsDialog}
         />
       )),
-    [environment, experiments],
+    [experiments, openGenerateTestIdsDialog, openForceEnrollmentDialog],
   );
 
   return (
-    <Container>
-      <h1 className="primary-fg my-3 fw-bold fs-3">{status} Experiments</h1>
-      <Row className="mb-3 text-center">
-        <Col md={4} className="d-flex align-items-center">
-          <Form.Label className="primary-fg fs-6 fw-bold me-2">
-            Environment:
-          </Form.Label>
-          <Form.Select
-            value={environment}
-            onChange={(e) => setEnvironment(e.target.value as Environment)}
-            className="grey-border rounded align-items-center"
-          >
-            <option value="prod">Production</option>
-            <option value="stage">Stage</option>
-          </Form.Select>
-        </Col>
-        <Col md={3} className="d-flex align-items-center">
-          <Form.Label className="primary-fg fs-6 fw-bold me-2">
-            Status:
-          </Form.Label>
-          <Form.Select
-            value={status}
-            onChange={(e) => setStatus(e.target.value as Status)}
-            className="grey-border rounded align-items-center"
-          >
-            <option value="Live">Live</option>
-            <option value="Preview">Preview</option>
-          </Form.Select>
-        </Col>
-        <Col md={3} className="d-flex align-items-start">
-          <Button
-            onClick={() => fetchExperiments(true)}
-            className="option-button primary-fg mx-2 py-2 px-3 rounded small-font fw-bold grey-border light-bg"
-          >
-            Refresh
-          </Button>
-        </Col>
-      </Row>
-      <Table hover>
-        <thead>
-          <tr>
-            <th className="text-center primary-fg light-bg">Experiment</th>
-            <th className="text-center primary-fg light-bg">Channel</th>
-            <th className="text-center primary-fg light-bg">Status</th>
-            <th className="text-center primary-fg light-bg">Actions</th>
-          </tr>
-        </thead>
-        <tbody>{experimentRows}</tbody>
-      </Table>
-    </Container>
+    <>
+      <Container>
+        <h1 className="primary-fg my-3 fw-bold fs-3">{status} Experiments</h1>
+        <Row className="mb-3 text-center">
+          <Col md={4} className="d-flex align-items-center">
+            <Form.Label className="primary-fg fs-6 fw-bold me-2">
+              Environment:
+            </Form.Label>
+            <Form.Select
+              value={environment}
+              onChange={(e) => setEnvironment(e.target.value as Environment)}
+              className="grey-border rounded align-items-center"
+            >
+              <option value="prod">Production</option>
+              <option value="stage">Stage</option>
+            </Form.Select>
+          </Col>
+          <Col md={3} className="d-flex align-items-center">
+            <Form.Label className="primary-fg fs-6 fw-bold me-2">
+              Status:
+            </Form.Label>
+            <Form.Select
+              value={status}
+              onChange={(e) => setStatus(e.target.value as Status)}
+              className="grey-border rounded align-items-center"
+            >
+              <option value="Live">Live</option>
+              <option value="Preview">Preview</option>
+            </Form.Select>
+          </Col>
+          <Col md={3} className="d-flex align-items-start">
+            <Button
+              onClick={() => fetchExperiments(true)}
+              className="option-button primary-fg mx-2 py-2 px-3 rounded small-font fw-bold grey-border light-bg"
+            >
+              Refresh
+            </Button>
+          </Col>
+        </Row>
+        <Table hover>
+          <thead>
+            <tr>
+              <th className="text-center primary-fg light-bg">Experiment</th>
+              <th className="text-center primary-fg light-bg">Channel</th>
+              <th className="text-center primary-fg light-bg">Status</th>
+              <th className="text-center primary-fg light-bg">Actions</th>
+            </tr>
+          </thead>
+          <tbody>{experimentRows}</tbody>
+        </Table>
+      </Container>
+
+      <ForceEnrollmentDialog
+        closeDialog={closeDialog}
+        environment={environment}
+        experiment={
+          dialogState?.kind === "force-enroll" ? dialogState.experiment : null
+        }
+      />
+      <GenerateTestIdsDialog
+        closeDialog={closeDialog}
+        experiment={
+          dialogState?.kind === "generate-test-ids"
+            ? dialogState.experiment
+            : null
+        }
+      />
+    </>
   );
 };
 
@@ -239,33 +425,6 @@ async function tryEnroll(
   } catch (error) {
     return {
       message: `Error enrolling into experiment: ${(error as Error).message ?? String(error)}`,
-      variant: "danger",
-    };
-  }
-}
-
-async function tryGenerateTestId(
-  experiment: NimbusExperiment,
-  branchSlug: string,
-): Promise<AddToastParams> {
-  try {
-    const result = await browser.experiments.nimbus.generateTestIds(
-      experiment,
-      branchSlug,
-    );
-    if (result) {
-      await navigator.clipboard.writeText(result);
-      return {
-        message: `Id copied to clipboard. Test Id: ${result}`,
-        variant: "success",
-        autohide: false,
-      };
-    } else {
-      return { message: "Test Id generation failed", variant: "danger" };
-    }
-  } catch (error) {
-    return {
-      message: `Error generating test Id: ${(error as Error).message ?? String(error)}`,
       variant: "danger",
     };
   }

--- a/src/ui/index.css
+++ b/src/ui/index.css
@@ -126,10 +126,6 @@ pre {
   background-color: var(--colour-gray);
 }
 
-.wide-column {
-  width: 18rem;
-}
-
 .grey-border {
   border: 2px solid var(--colour-gray);
 }


### PR DESCRIPTION
Previously, the experiment browser had a branch selector and action selector for each row. Now, the branch selector has been removed from the rows and each action (force enroll and generate test IDs) will now open modals with more options: 

* The generate test IDs action now presents a modal with options to copy test IDs for individual branches, or a JSON blob containing a mapping of branches to test IDs. As such, the generateTestIds web extension API has been updated to always return the full mapping, instead of just the test ID for a single branch. It was generating all test IDs previously, but it was throwing away everything but the test ID for the requested branch.

* The force enroll action now opens a modal with a branch selector. The branch selector defaults to the first branch for single-branch experiements.

This change will enable adding additional actions that do not require branch selectors.