### PR TITLE
Support opening the JEXL debugger directly from Experimenter

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -6,9 +6,7 @@
 import { MessageKind } from "./messages";
 
 browser.browserAction.onClicked.addListener(() =>
-  browser.tabs.create({
-    url: "./ui/index.html",
-  }),
+  browser.tabs.create({ url: "./ui/index.html" }),
 );
 
 browser.runtime.onMessage.addListener(
@@ -23,6 +21,10 @@ browser.runtime.onMessage.addListener(
     }
 
     switch (message.kind) {
+      case MessageKind.DEBUG_JEXL:
+        openJexlDebugger(message.jexlExpression);
+        break;
+
       case MessageKind.FORCE_ENROLL:
         browser.experiments.nimbus
           .forceEnroll(message.recipe, message.branchSlug)
@@ -45,7 +47,6 @@ browser.runtime.onMessage.addListener(
         break;
 
       case MessageKind.SUBSTITUTE_LOCALIZATIONS:
-        console.log(message.values, message.localizations);
         browser.experiments.nimbus
           .substituteLocalizations(message.values, message.localizations)
           .then(
@@ -63,3 +64,12 @@ browser.runtime.onMessage.addListener(
     return undefined;
   },
 );
+
+function openJexlDebugger(jexlExpression) {
+  const searchParams = new URLSearchParams();
+
+  searchParams.append("view", "jexl-debugger");
+  searchParams.append("jexlExpression", jexlExpression);
+
+  browser.tabs.create({ url: `./ui/index.html?${searchParams}` });
+}

--- a/src/background/messages.js
+++ b/src/background/messages.js
@@ -4,6 +4,7 @@
  */
 
 export const MessageKind = Object.freeze({
+  DEBUG_JEXL: "nimbus-devtools:debugJexl",
   FORCE_ENROLL: "nimbus-devtools:forceEnroll",
   GET_MESSAGING_FEATURES_AND_TEMPLATES:
     "nimbus-devtools:getMessagingFeaturesAndTemplates",

--- a/src/contentScripts/experimenter.js
+++ b/src/contentScripts/experimenter.js
@@ -141,6 +141,24 @@ class ExperimenterIntegration {
             });
         }
       });
+
+    document
+      .querySelectorAll("textarea[data-nimbus-devtools-targeting-expression]")
+      .forEach((textarea) => {
+        const container = textarea.closest(".readonly-json-collapsible");
+        if (!container) {
+          return;
+        }
+
+        container
+          .querySelectorAll("[data-nimbus-devtools-debug-jexl-button]")
+          .forEach((button) => {
+            button.addEventListener("click", () =>
+              NimbusDevtoolsAPI.debugJexl(textarea.value),
+            );
+            button.classList.remove("d-none");
+          });
+      });
   }
 
   /**

--- a/src/contentScripts/lib/api.js
+++ b/src/contentScripts/lib/api.js
@@ -6,6 +6,13 @@
 import { MessageKind } from "../../background/messages";
 
 export default {
+  async debugJexl(jexlExpression) {
+    return browser.runtime.sendMessage({
+      kind: MessageKind.DEBUG_JEXL,
+      jexlExpression,
+    });
+  },
+
   async getMessagingFeaturesAndTemplates() {
     return browser.runtime.sendMessage({
       kind: MessageKind.GET_MESSAGING_FEATURES_AND_TEMPLATES,
@@ -28,7 +35,6 @@ export default {
   },
 
   async substituteLocalizations(values, localizations) {
-    console.log(values, localizations);
     const result = await browser.runtime.sendMessage({
       kind: MessageKind.SUBSTITUTE_LOCALIZATIONS,
       values,

--- a/src/ui/components/JEXLDebuggerPage.tsx
+++ b/src/ui/components/JEXLDebuggerPage.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
 } from "react";
 import { Container, Row, Col, Form, Button } from "react-bootstrap";
 import { useLocation } from "react-router-dom";
@@ -126,6 +127,7 @@ type JEXLDebuggerPageState = {
 };
 
 const JEXLDebuggerPage: FC = () => {
+  const mounted = useRef<boolean>(false);
   const [originalContext, setOriginalContext] = useState<
     Record<string, ContextValue>
   >({});
@@ -201,24 +203,20 @@ const JEXLDebuggerPage: FC = () => {
     [],
   );
 
-  const handleEvaluateClick = useCallback(async () => {
-    try {
-      if (jexlExpression === "") {
-        setOutput("Error evaluating expression");
-      } else {
-        const result = await evaluateJexl(jexlExpression, {
-          ...originalContext,
-          ...modifiedContext,
+  const evaluateExpression = useCallback(() => {
+    evaluateJexl(jexlExpression, {
+      ...originalContext,
+      ...modifiedContext,
+    }).then(
+      (result) => setOutput(result),
+      (error) => {
+        setOutput("Evaluation error");
+        addToast({
+          message: `Error evaluating expression: ${(error as Error).message ?? String(error)}`,
+          variant: "danger",
         });
-        setOutput(result);
-      }
-    } catch (error) {
-      setOutput("Error evaluating expression");
-      addToast({
-        message: `Error evaluating expression: ${(error as Error).message ?? String(error)}`,
-        variant: "danger",
-      });
-    }
+      },
+    );
   }, [jexlExpression, modifiedContext, originalContext, addToast]);
 
   const parseAndSetContext = useMemo(() => {
@@ -293,6 +291,14 @@ const JEXLDebuggerPage: FC = () => {
     [parseAndSetContext],
   );
 
+  useEffect(() => {
+    if (!mounted.current && locationState?.jexlExpression) {
+      evaluateExpression();
+    }
+
+    mounted.current = true;
+  }, [locationState?.jexlExpression, evaluateExpression]);
+
   return (
     <Container className="main-content">
       <Row className="justify-content-start pb-2 px-2 pt-3">
@@ -307,7 +313,7 @@ const JEXLDebuggerPage: FC = () => {
             rows={8}
           />
           <Button
-            onClick={handleEvaluateClick}
+            onClick={evaluateExpression}
             className="mt-2 py-2 px-4 fs-6 border-0 w-100 rounded text-white dark-button"
           >
             Evaluate

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -10,6 +10,7 @@ import {
   Routes,
   Route,
   Navigate,
+  useSearchParams,
 } from "react-router-dom";
 import { Container } from "react-bootstrap";
 
@@ -24,6 +25,22 @@ import ExperimentStorePage from "./components/ExperimentStorePage";
 import useToasts from "./hooks/useToasts";
 import Toasts from "./components/Toasts";
 
+const IndexRoute = () => {
+  const [searchParams] = useSearchParams(document.location.search);
+
+  if (searchParams.get("view") === "jexl-debugger") {
+    const jexlExpression = searchParams.get("jexlExpression");
+
+    if (jexlExpression) {
+      return (
+        <Navigate to="/jexl-debugger" state={{ jexlExpression }} replace />
+      );
+    }
+  }
+
+  return <Navigate to="/experiment-json" replace />;
+};
+
 const App = () => {
   const toastCtx = useToasts();
 
@@ -35,10 +52,7 @@ const App = () => {
           <Sidebar />
           <Container className="main-content">
             <Routes>
-              <Route
-                path="/"
-                element={<Navigate to="/experiment-json" replace />}
-              />
+              <Route path="/" element={<IndexRoute />} />
               <Route
                 path="/experiment-json"
                 element={<RecipeEnrollmentPage />}

--- a/src/ui/jexlParser.ts
+++ b/src/ui/jexlParser.ts
@@ -29,6 +29,10 @@ export async function evaluateJexl(
   expression: string,
   context: object = {},
 ): Promise<string> {
+  if (!expression.trim()) {
+    throw new Error("Empty expression");
+  }
+
   const lexer = new Lexer(grammar);
   const parser = new Parser(grammar);
 


### PR DESCRIPTION
As of mozilla/experimenter#14977, there are now "debug in nimbus-devtools" widgets for the targeting of each recipe. This patch provides a way (via using URL search params) to specify that the JEXL debugger should be opened directly with a specific URL.

In order to make the linters happy, the JEXLDebuggerPage's effects had to be rewritten in order to use promises, because the eslint-plugin-react-hooks plugin does not properly lint async functions. All validation of JEXL expressions, including checking if the expression is non-empty, has been moved into the async `evaluateJexl` function so that it must be awaited (or in this case then()-ed) before calling setState functions to appease the linter.