### PR TITLE
Call forceEnroll() with branchSlug instead of branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     }
   },
   "browserslist": [
-    "firefox >= 150",
+    "firefox >= 152",
     "unreleased firefox versions"
   ],
   "@parcel/transformer-js": {

--- a/src/apis/nimbus.js
+++ b/src/apis/nimbus.js
@@ -312,12 +312,9 @@ var nimbus = class extends ExtensionAPI {
 
           async forceEnroll(recipe, branchSlug) {
             try {
-              const branch = recipe?.branches?.find(
-                (br) => br.slug === branchSlug,
-              );
               const result = await ExperimentManager.forceEnroll(
                 recipe,
-                branch,
+                branchSlug,
               );
               return result !== null;
             } catch (error) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,7 +5,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "nimbus-devtools@mozilla.com",
-      "strict_min_version": "150.0a1",
+      "strict_min_version": "152.0a1",
       "data_collection_permissions": {
         "required": ["none"]
       }


### PR DESCRIPTION
The minimum version of Firefox supported is now 152.

Fixes #196