### PR TITLE
Support co-enrollment

### DIFF
--- a/src/apis/nimbus.js
+++ b/src/apis/nimbus.js
@@ -61,43 +61,71 @@ var nimbus = class extends ExtensionAPI {
     return {
       experiments: {
         nimbus: {
-          async enrollInExperiment(jsonData, forceEnroll) {
+          async enrollInExperiment(recipe, forceEnroll) {
             try {
-              const { slug, isRollout = false } = jsonData;
+              const { slug } = recipe;
 
               const slugExistsInStore = ExperimentManager.store
                 .getAll()
                 .some((experiment) => experiment.slug === slug);
-              const activeEnrollment =
-                ExperimentManager.store
-                  .getAll()
-                  .find(
-                    (experiment) =>
-                      experiment.slug === slug &&
-                      experiment.isRollout === isRollout &&
-                      experiment.active,
-                  )?.slug ?? null;
-              if (slugExistsInStore || activeEnrollment) {
-                if (!forceEnroll) {
-                  return {
-                    enrolled: false,
-                    error: { slugExistsInStore, activeEnrollment },
-                  };
-                }
 
-                if (activeEnrollment) {
-                  this.unenroll(activeEnrollment);
-                }
-                if (slugExistsInStore) {
-                  this.deleteInactiveEnrollment(jsonData.slug);
+              const canEnroll = ExperimentManager.canEnroll(recipe);
+              if (!canEnroll.ok) {
+                switch (canEnroll.reason) {
+                  case "enrollment-paused":
+                    // Allow enrollment in paused recipes.
+                    break;
+
+                  case "does-not-exist":
+                    throw new Error(
+                      `Feature ${canEnroll.featureId} does not exist`,
+                    );
+
+                  case "enrolled-in-feature":
+                    if (!forceEnroll) {
+                      return {
+                        enrolled: false,
+                        error: {
+                          activeEnrollments: Array.from(
+                            canEnroll.conflictingEnrollments,
+                          ),
+                          slugExistsInStore,
+                        },
+                      };
+                    }
+
+                    for (const conflictingSlug of canEnroll.conflictingEnrollments) {
+                      this.unenroll(conflictingSlug);
+                    }
+                    break;
+
+                  default:
+                    console.error(
+                      `Cannot enroll: unexpected reason ${canEnroll.reason}`,
+                      canEnroll,
+                    );
+                    throw new Error(
+                      `Cannot enroll: unexpected reason ${canEnroll.reason}`,
+                    );
                 }
               }
 
-              const result = await ExperimentManager.enroll(
-                jsonData,
+              if (slugExistsInStore) {
+                if (!forceEnroll) {
+                  return {
+                    enrolled: false,
+                    error: { slugExistsInStore },
+                  };
+                }
+
+                this.deleteInactiveEnrollment(recipe.slug);
+              }
+
+              const enrollment = await ExperimentManager.enroll(
+                recipe,
                 "nimbus-devtools",
               );
-              return { enrolled: result !== null, error: null };
+              return { enrolled: enrollment !== null, error: null };
             } catch (error) {
               console.error(error);
               throw new ExtensionError(String(error));
@@ -110,13 +138,7 @@ var nimbus = class extends ExtensionAPI {
             isRollout,
             forceEnroll,
           ) {
-            let userFacingName = `Nimbus Devtools ${featureId} Enrollment`;
-
-            if (isRollout) {
-              userFacingName += " (rollout)";
-            }
-
-            const slug = `nimbus-devtools-${featureId}-${isRollout ? "rollout" : "experiment"}`;
+            const uuid = Services.uuid.generateUUID().toString().slice(1, -1);
             const recipe = {
               bucketConfig: {
                 namespace: "devtools-test",
@@ -139,49 +161,12 @@ var nimbus = class extends ExtensionAPI {
               ],
               isRollout,
               featureIds: [featureId],
-              slug,
-              userFacingName,
+              slug: `nimbus-devtools-${featureId}-${isRollout ? "rollout" : "experiment"}-${uuid}`,
+              userFacingName: `nimbus-devtools ${featureId} ${isRollout ? "Rollout" : "Experiment"} (${uuid})`,
               userFacingDescription: `Testing the feature with feature ID: ${featureId}.`,
             };
 
-            try {
-              const slugExistsInStore = ExperimentManager.store
-                .getAll()
-                .some((experiment) => experiment.slug === recipe.slug);
-              const activeEnrollment =
-                ExperimentManager.store
-                  .getAll()
-                  .find(
-                    (experiment) =>
-                      experiment.featureIds.includes(featureId) &&
-                      experiment.isRollout === isRollout &&
-                      experiment.active,
-                  )?.slug ?? null;
-
-              if (slugExistsInStore || activeEnrollment) {
-                if (!forceEnroll) {
-                  return {
-                    enrolled: false,
-                    error: { slugExistsInStore, activeEnrollment },
-                  };
-                }
-
-                if (activeEnrollment) {
-                  this.unenroll(activeEnrollment);
-                }
-                if (slugExistsInStore) {
-                  this.deleteInactiveEnrollment(slug);
-                }
-              }
-              const result = await ExperimentManager.enroll(
-                recipe,
-                "nimbus-devtools",
-              );
-              return { enrolled: result !== null, error: null };
-            } catch (error) {
-              console.error(error);
-              throw new ExtensionError(String(error));
-            }
+            return this.enrollInExperiment(recipe, forceEnroll);
           },
 
           async getFeatureConfigs() {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -125,7 +125,7 @@ type EnrollInExperimentResult =
       enrolled: false;
       error: {
         slugExistsInStore: boolean;
-        activeEnrollment: string | null;
+        activeEnrollments?: string[];
       };
     };
 

--- a/src/ui/components/EnrollmentError.tsx
+++ b/src/ui/components/EnrollmentError.tsx
@@ -7,51 +7,36 @@ const EnrollmentError: FC<{
   if (!enrollError) {
     return null;
   }
-  const { activeEnrollment, slugExistsInStore } = enrollError;
+  const { activeEnrollments, slugExistsInStore } = enrollError;
 
-  if (activeEnrollment && slugExistsInStore && slug == activeEnrollment) {
-    return (
-      <p>
-        There is already an enrollment for the slug: <strong>{slug}</strong>.
-        Would you like to proceed with force enrollment by unenrolling,
-        deleting, and enrolling into the new configuration?
-      </p>
-    );
-  } else if (
-    activeEnrollment &&
-    slugExistsInStore &&
-    slug !== activeEnrollment
-  ) {
-    return (
-      <p>
-        There is already an active enrollment for the feature with a different
-        slug. Would you like to proceed with force enrollment by unenrolling,
-        deleting, and enrolling into the new configuration?
-      </p>
-    );
-  }
+  return (
+    <>
+      {activeEnrollments && (
+        <>
+          <p>
+            There are one or more active enrollments that are in conflict with
+            this new enrollment. Force enrolling will unenroll from these
+            enrollments:
+          </p>
+          <ul>
+            {activeEnrollments.map((slug) => (
+              <li key={slug}>
+                <code>{slug}</code>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
 
-  if (activeEnrollment) {
-    return (
-      <p>
-        There is an active enrollment for the slug:{" "}
-        <strong>{activeEnrollment}</strong>. Would you like to unenroll from the
-        active enrollment and enroll into the new configuration?
-      </p>
-    );
-  }
-
-  if (slugExistsInStore) {
-    return (
-      <p>
-        There is an inactive enrollment stored for the slug:{" "}
-        <strong>{slug}</strong>. Would you like to delete the inactive
-        enrollment and enroll into the new configuration?
-      </p>
-    );
-  }
-
-  return null;
+      {slugExistsInStore && (
+        <p>
+          An enrollment with the slug <code>{slug}</code> already exists in the
+          enrollment store. Force enrolling will <strong>delete</strong> this
+          enrollment from the store.
+        </p>
+      )}
+    </>
+  );
 };
 
 export default EnrollmentError;

--- a/src/ui/components/FeatureConfigPage.tsx
+++ b/src/ui/components/FeatureConfigPage.tsx
@@ -79,7 +79,7 @@ const FeatureConfigPage: FC = () => {
 
   const handleModalConfirm = useCallback(async () => {
     setEnrollError(null);
-    await handleEnrollClick(null, true);
+    await handleEnrollClick(undefined, true);
   }, [handleEnrollClick]);
 
   const handleModalClose = useCallback(() => {

--- a/src/ui/components/RecipeEnrollmentPage.tsx
+++ b/src/ui/components/RecipeEnrollmentPage.tsx
@@ -100,7 +100,12 @@ const RecipeEnrollmentPage: FC = () => {
           <Modal.Title>Force Enrollment</Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <EnrollmentError slug={enrollError?.slug} enrollError={enrollError} />
+          {enrollError && (
+            <EnrollmentError
+              slug={enrollError.slug}
+              enrollError={enrollError}
+            />
+          )}
         </Modal.Body>
         <Modal.Footer>
           <Button variant="secondary" onClick={handleModalClose}>


### PR DESCRIPTION
The Recipe Enrollment and Feature Config Enrollment features now respect co-enrolling features. We now call `ExperimentManager.canEnroll()` (which is co-enrollment aware) to determine enrollment conflicts. Additionally, the feature config enrollment logic has been refactored to re-use the existing recipe enrollment logic. These two refactors have resulted in more linear control flow.

As a result of calling `canEnroll()`, we now get the entire list of conflicting enrollments in the case of multi-feature recipes instead of just the first recipe we find. This also fixes the case where enrolling into a multi-feature recipe with multiple conflicts would fail due to not unenrolling from all conflicting enrollments.

The `<EnrollmentError>` component has been updated to support multiple conflicting slugs, as well as simplified to show more generic error messages that indicate exactly what will happen.

In order to support co-enrolling features, we now always append a UUID to the end of generated slugs and user-facing recipe names when generating a recipe for feature configuration enrollment.

Fixes #197