### PR TITLE
Specify type for setState in FeatureConfigSelector

### DIFF
--- a/src/ui/components/FeatureConfigPage.tsx
+++ b/src/ui/components/FeatureConfigPage.tsx
@@ -2,8 +2,8 @@ import { ChangeEvent, FC, useState, useCallback, useMemo } from "react";
 import { Form, Container, Button, Row, Col, Modal } from "react-bootstrap";
 
 import { useToastsContext } from "../hooks/useToasts";
-import DropdownMenu from "./DropdownMenu";
 import EnrollmentError from "./EnrollmentError";
+import FeatureConfigSelector from "./FeatureConfigSelector";
 
 const FeatureConfigPage: FC = () => {
   const [jsonInput, setJsonInput] = useState("");
@@ -91,7 +91,9 @@ const FeatureConfigPage: FC = () => {
       <Form>
         <Row className="align-items-stretch">
           <Col md={9}>
-            <DropdownMenu onSelectFeatureConfigId={handleFeatureSelect} />
+            <FeatureConfigSelector
+              onSelectFeatureConfigId={handleFeatureSelect}
+            />
           </Col>
           <Col md={3} className="ps-0">
             <Container className="checkbox-border d-flex rounded p-2 grey-border">

--- a/src/ui/components/FeatureConfigSelector.tsx
+++ b/src/ui/components/FeatureConfigSelector.tsx
@@ -3,12 +3,14 @@ import { Form } from "react-bootstrap";
 
 import { useToastsContext } from "../hooks/useToasts";
 
-type DropdownMenuProps = {
+type FeatureConfigSelectorProps = {
   onSelectFeatureConfigId: (featureId: string) => void;
 };
 
-const DropdownMenu: FC<DropdownMenuProps> = ({ onSelectFeatureConfigId }) => {
-  const [featureConfigs, setFeatureConfigs] = useState([]);
+const FeatureConfigSelector: FC<FeatureConfigSelectorProps> = ({
+  onSelectFeatureConfigId,
+}) => {
+  const [featureConfigs, setFeatureConfigs] = useState<string[]>([]);
   const { addToast } = useToastsContext();
 
   useEffect(() => {
@@ -51,4 +53,4 @@ const DropdownMenu: FC<DropdownMenuProps> = ({ onSelectFeatureConfigId }) => {
   );
 };
 
-export default DropdownMenu;
+export default FeatureConfigSelector;


### PR DESCRIPTION
The type of the state was being inferred by the TypeScript LSP as `never[]`. Adding a type of `string[]` fixes the inference.

The `<DropdownMenu />` component has been renamed to `<FeatureConfigSelector />` because it is only for selecting feature IDs and is not a generic dropdown menu.