### PR TITLE
Update our tsconfig to be compatible with TypeScript 7

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "isolatedModules": true, // For Parcel
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "target": "ES2022",
     "jsx": "react-jsx",
     "module": "ES2022",


### PR DESCRIPTION
We do not need to use the `baseUrl` option because we specify full import paths.

We are using Parcel to bundle so we should be using the "bundler" module resolution scheme.